### PR TITLE
Fixed ui render bug

### DIFF
--- a/packages/ant-design/src/WalletModal.tsx
+++ b/packages/ant-design/src/WalletModal.tsx
@@ -61,7 +61,7 @@ export const WalletModal: FC<WalletModalProps> = ({
                         wallet={wallet}
                     />
                 ))}
-                {more.length && (
+                {more.length ? (
                     <Menu.SubMenu key="wallet-adapter-modal-submenu" title={`${expanded ? 'Less' : 'More'} options`}>
                         {more.map((wallet) => (
                             <WalletMenuItem
@@ -71,7 +71,7 @@ export const WalletModal: FC<WalletModalProps> = ({
                             />
                         ))}
                     </Menu.SubMenu>
-                )}
+                ) : null}
             </Menu>
         </Modal>
     );

--- a/packages/material-ui/src/WalletDialog.tsx
+++ b/packages/material-ui/src/WalletDialog.tsx
@@ -133,7 +133,7 @@ export const WalletDialog: FC<WalletDialogProps> = ({
                             wallet={wallet}
                         />
                     ))}
-                    {more.length && (
+                    {more.length ? (
                         <>
                             <Collapse in={expanded} timeout="auto" unmountOnExit>
                                 <List>
@@ -153,7 +153,7 @@ export const WalletDialog: FC<WalletDialogProps> = ({
                                 </Button>
                             </ListItem>
                         </>
-                    )}
+                    ) : null}
                 </List>
             </DialogContent>
         </Dialog>

--- a/packages/react-ui/src/WalletModal.tsx
+++ b/packages/react-ui/src/WalletModal.tsx
@@ -147,7 +147,7 @@ export const WalletModal: FC<WalletModalProps> = ({
                                 />
                             ))}
                         </ul>
-                        {more.length && (
+                        {more.length ? (
                             <>
                                 <Collapse expanded={expanded} id="wallet-adapter-modal-collapse">
                                     <ul className="wallet-adapter-modal-list">
@@ -177,7 +177,7 @@ export const WalletModal: FC<WalletModalProps> = ({
                                     {expanded ? 'Less' : 'More'} options
                                 </Button>
                             </>
-                        )}
+                        ) : null}
                     </div>
                 </div>
                 <div className="wallet-adapter-modal-overlay" onMouseDown={handleClose} />


### PR DESCRIPTION
Fixed a render bug caused by short circuit evaluation on the modal collapse.
A "0" would render after the wallets list if you included every wallet in the featured wallets section.

The bug happened when trying to render every wallet without showing the "More options" button.

Fixed by replacing the short circuit evaluation with a ternary operator inside the render functions.