### PR TITLE
Fix disconnect state

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-react",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/react/src/WalletProvider.tsx
+++ b/packages/react/src/WalletProvider.tsx
@@ -112,7 +112,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     }, [adapter, setState]);
 
     // Handle the adapter's disconnect event
-    const onDisconnect = useCallback(() => setState(initialState), [setState]);
+    const onDisconnect = useCallback(() => setName(null), [setState]);
 
     // Connect the adapter to the wallet
     const connect = useCallback(async () => {


### PR DESCRIPTION
Fixes #68

Setting the selected wallet name to null causes the state to be set to initialState anyway.