### PR TITLE
[FIX] Yarn dependency command updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install these dependencies:
 yarn add @solana/wallet-adapter-wallets \
          @solana/wallet-adapter-base \
          @solana/wallet-adapter-react \
-         @solana/wallet-adapter-react-ui
+         @solana/wallet-adapter-react-ui \
          @solana/web3.js \
          react
 ```


### PR DESCRIPTION
Yarn add command in the readme was missing a "\" causing it not to copy/paste right.