### PR TITLE
Loosen `@types/react` dependency

### DIFF
--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -25,13 +25,11 @@
         "@solana/web3.js": "^1.20.0",
         "react": "^17.0.2"
     },
-    "dependencies": {
-        "@types/react": "*"
-    },
     "devDependencies": {
         "@solana/wallet-adapter-base": "^0.6.0",
         "@solana/wallet-adapter-wallets": "^0.10.0",
         "@solana/web3.js": "^1.20.0",
+        "@types/react": "^17.0.24",
         "react": "^17.0.2"
     }
 }

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -26,7 +26,7 @@
         "react": "^17.0.2"
     },
     "dependencies": {
-        "@types/react": "^17.0.16"
+        "@types/react": "*"
     },
     "devDependencies": {
         "@solana/wallet-adapter-base": "^0.6.0",

--- a/packages/ui/ant-design/package.json
+++ b/packages/ui/ant-design/package.json
@@ -30,7 +30,7 @@
         "react-dom": "^17.0.2"
     },
     "dependencies": {
-        "@types/react": "^17.0.16"
+        "@types/react": "*"
     },
     "devDependencies": {
         "@ant-design/icons": "^4.6.3",

--- a/packages/ui/ant-design/package.json
+++ b/packages/ui/ant-design/package.json
@@ -29,15 +29,13 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     },
-    "dependencies": {
-        "@types/react": "*"
-    },
     "devDependencies": {
         "@ant-design/icons": "^4.6.3",
         "@solana/wallet-adapter-base": "^0.6.0",
         "@solana/wallet-adapter-react": "^0.12.0",
         "@solana/wallet-adapter-wallets": "^0.10.0",
         "@solana/web3.js": "^1.20.0",
+        "@types/react": "^17.0.24",
         "antd": "^4.16.11",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"

--- a/packages/ui/material-ui/package.json
+++ b/packages/ui/material-ui/package.json
@@ -30,7 +30,7 @@
         "react-dom": "^17.0.2"
     },
     "dependencies": {
-        "@types/react": "^17.0.16"
+        "@types/react": "*"
     },
     "devDependencies": {
         "@material-ui/core": "^4.12.1",

--- a/packages/ui/material-ui/package.json
+++ b/packages/ui/material-ui/package.json
@@ -29,9 +29,6 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     },
-    "dependencies": {
-        "@types/react": "*"
-    },
     "devDependencies": {
         "@material-ui/core": "^4.12.1",
         "@material-ui/icons": "^4.11.2",
@@ -39,6 +36,7 @@
         "@solana/wallet-adapter-react": "^0.12.0",
         "@solana/wallet-adapter-wallets": "^0.10.0",
         "@solana/web3.js": "^1.20.0",
+        "@types/react": "^17.0.24",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     }

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -27,14 +27,12 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     },
-    "dependencies": {
-        "@types/react": "*"
-    },
     "devDependencies": {
         "@solana/wallet-adapter-base": "^0.6.0",
         "@solana/wallet-adapter-react": "^0.12.0",
         "@solana/wallet-adapter-wallets": "^0.10.0",
         "@solana/web3.js": "^1.20.0",
+        "@types/react": "^17.0.24",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     }

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -28,7 +28,7 @@
         "react-dom": "^17.0.2"
     },
     "dependencies": {
-        "@types/react": "^17.0.16"
+        "@types/react": "*"
     },
     "devDependencies": {
         "@solana/wallet-adapter-base": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,7 +3733,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.16", "@types/react@^17.0.20":
+"@types/react@*", "@types/react@^17.0.16", "@types/react@^17.0.20", "@types/react@^17.0.24":
   version "17.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.24.tgz#7e1b3f78d0fc53782543f9bce6d949959a5880bd"
   integrity sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==


### PR DESCRIPTION
these packages ultimately are consumed by applications which will determine what version of `@types/react` to use. when the consumer has an incompatible version of `@types/react`, _both_ end up getting installed by `yarn` which causes some duplication of types, causing `tsc` to fail to build the consumer. see more information about the failure mode here: https://stackoverflow.com/questions/52399839/duplicate-identifier-librarymanagedattributes

i chose not to loosen the types in the starter packages, since those are technically the "consumers" of these packages. however, the packages here (`@solana/wallet-adapter-react`, `@solana/wallet-adapter-material-ui`, `@solana/wallet-adapter-ant-design`, `@solana/wallet-adapter-react-ui`) are not standalone packages, so packages that have dependencies here would be the ones establishing the proper version for `@types/react`. 

see this [PR](https://github.com/metaplex-foundation/metaplex/pull/473#issuecomment-925456319) for the sort of fix that has to be put in place by consumers otherwise