### PR TITLE
Assign type="button" attribute to button tags

### DIFF
--- a/packages/ui/ant-design/src/WalletConnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletConnectButton.tsx
@@ -6,6 +6,7 @@ import { WalletIcon } from './WalletIcon';
 export const WalletConnectButton: FC<ButtonProps> = ({
     type = 'primary',
     size = 'large',
+    htmlType = 'button',
     children,
     disabled,
     onClick,
@@ -40,6 +41,7 @@ export const WalletConnectButton: FC<ButtonProps> = ({
             icon={<WalletIcon wallet={wallet} />}
             type={type}
             size={size}
+            htmlType={htmlType}
             {...props}
         >
             {content}

--- a/packages/ui/ant-design/src/WalletDisconnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletDisconnectButton.tsx
@@ -6,6 +6,7 @@ import { WalletIcon } from './WalletIcon';
 export const WalletDisconnectButton: FC<ButtonProps> = ({
     type = 'primary',
     size = 'large',
+    htmlType = 'button',
     children,
     disabled,
     onClick,
@@ -39,6 +40,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({
             icon={<WalletIcon wallet={wallet} />}
             type={type}
             size={size}
+            htmlType={htmlType}
             {...props}
         >
             {content}

--- a/packages/ui/ant-design/src/WalletMenuItem.tsx
+++ b/packages/ui/ant-design/src/WalletMenuItem.tsx
@@ -16,6 +16,7 @@ export const WalletMenuItem: FC<WalletMenuItemProps> = ({ onClick, wallet, ...pr
                 icon={<WalletIcon wallet={wallet} className="wallet-adapter-modal-menu-button-icon" />}
                 type="text"
                 className="wallet-adapter-modal-menu-button"
+                htmlType="button"
                 block
             >
                 {wallet.name}

--- a/packages/ui/ant-design/src/WalletModalButton.tsx
+++ b/packages/ui/ant-design/src/WalletModalButton.tsx
@@ -6,6 +6,7 @@ export const WalletModalButton: FC<ButtonProps> = ({
     children = 'Select Wallet',
     type = 'primary',
     size = 'large',
+    htmlType = 'button',
     onClick,
     ...props
 }) => {
@@ -20,7 +21,7 @@ export const WalletModalButton: FC<ButtonProps> = ({
     );
 
     return (
-        <Button onClick={handleClick} type={type} size={size} {...props}>
+        <Button onClick={handleClick} type={type} size={size} htmlType={htmlType} {...props}>
             {children}
         </Button>
     );

--- a/packages/ui/ant-design/src/WalletMultiButton.tsx
+++ b/packages/ui/ant-design/src/WalletMultiButton.tsx
@@ -11,7 +11,13 @@ import { WalletConnectButton } from './WalletConnectButton';
 import { WalletIcon } from './WalletIcon';
 import { WalletModalButton } from './WalletModalButton';
 
-export const WalletMultiButton: FC<ButtonProps> = ({ type = 'primary', size = 'large', children, ...props }) => {
+export const WalletMultiButton: FC<ButtonProps> = ({
+    type = 'primary',
+    size = 'large',
+    htmlType = 'button',
+    children,
+    ...props
+}) => {
     const { publicKey, wallet, disconnect } = useWallet();
     const { setVisible } = useWalletModal();
 
@@ -24,14 +30,14 @@ export const WalletMultiButton: FC<ButtonProps> = ({ type = 'primary', size = 'l
 
     if (!wallet) {
         return (
-            <WalletModalButton type={type} size={size} {...props}>
+            <WalletModalButton type={type} size={size} htmlType={htmlType} {...props}>
                 {children}
             </WalletModalButton>
         );
     }
     if (!base58) {
         return (
-            <WalletConnectButton type={type} size={size} {...props}>
+            <WalletConnectButton type={type} size={size} htmlType={htmlType} {...props}>
                 {children}
             </WalletConnectButton>
         );
@@ -46,6 +52,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({ type = 'primary', size = 'l
                             icon={<WalletIcon wallet={wallet} />}
                             type={type}
                             size={size}
+                            htmlType={htmlType}
                             className="wallet-adapter-multi-button-menu-button"
                             block
                             {...props}
@@ -85,7 +92,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({ type = 'primary', size = 'l
             }
             trigger={['click']}
         >
-            <Button icon={<WalletIcon wallet={wallet} />} type={type} size={size} {...props}>
+            <Button icon={<WalletIcon wallet={wallet} />} type={type} size={size} htmlType={htmlType} {...props}>
                 {content}
             </Button>
         </Dropdown>

--- a/packages/ui/material-ui/src/WalletConnectButton.tsx
+++ b/packages/ui/material-ui/src/WalletConnectButton.tsx
@@ -6,6 +6,7 @@ import { WalletIcon } from './WalletIcon';
 export const WalletConnectButton: FC<ButtonProps> = ({
     color = 'primary',
     variant = 'contained',
+    type = 'button',
     children,
     disabled,
     onClick,
@@ -37,6 +38,7 @@ export const WalletConnectButton: FC<ButtonProps> = ({
         <Button
             color={color}
             variant={variant}
+            type={type}
             onClick={handleClick}
             disabled={disabled || !wallet || connecting || connected}
             startIcon={<WalletIcon wallet={wallet} />}

--- a/packages/ui/material-ui/src/WalletDialogButton.tsx
+++ b/packages/ui/material-ui/src/WalletDialogButton.tsx
@@ -6,6 +6,7 @@ export const WalletDialogButton: FC<ButtonProps> = ({
     children = 'Select Wallet',
     color = 'primary',
     variant = 'contained',
+    type = 'button',
     onClick,
     ...props
 }) => {
@@ -20,7 +21,7 @@ export const WalletDialogButton: FC<ButtonProps> = ({
     );
 
     return (
-        <Button color={color} variant={variant} onClick={handleClick} {...props}>
+        <Button color={color} variant={variant} type={type} onClick={handleClick} {...props}>
             {children}
         </Button>
     );

--- a/packages/ui/material-ui/src/WalletDisconnectButton.tsx
+++ b/packages/ui/material-ui/src/WalletDisconnectButton.tsx
@@ -6,6 +6,7 @@ import { WalletIcon } from './WalletIcon';
 export const WalletDisconnectButton: FC<ButtonProps> = ({
     color = 'primary',
     variant = 'contained',
+    type = 'button',
     children,
     disabled,
     onClick,
@@ -36,6 +37,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({
         <Button
             color={color}
             variant={variant}
+            type={type}
             onClick={handleClick}
             disabled={disabled || !wallet}
             startIcon={<WalletIcon wallet={wallet} />}

--- a/packages/ui/material-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/material-ui/src/WalletMultiButton.tsx
@@ -53,6 +53,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const WalletMultiButton: FC<ButtonProps> = ({
     color = 'primary',
     variant = 'contained',
+    type = 'button',
     children,
     ...props
 }) => {
@@ -70,14 +71,14 @@ export const WalletMultiButton: FC<ButtonProps> = ({
 
     if (!wallet) {
         return (
-            <WalletDialogButton color={color} variant={variant} {...props}>
+            <WalletDialogButton color={color} variant={variant} type={type} {...props}>
                 {children}
             </WalletDialogButton>
         );
     }
     if (!base58) {
         return (
-            <WalletConnectButton color={color} variant={variant} {...props}>
+            <WalletConnectButton color={color} variant={variant} type={type} {...props}>
                 {children}
             </WalletConnectButton>
         );
@@ -88,6 +89,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({
             <Button
                 color={color}
                 variant={variant}
+                type={type}
                 startIcon={<WalletIcon wallet={wallet} />}
                 onClick={(event) => setAnchor(event.currentTarget)}
                 aria-controls="wallet-menu"
@@ -112,6 +114,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({
                     <Button
                         color={color}
                         variant={variant}
+                        type={type}
                         startIcon={<WalletIcon wallet={wallet} />}
                         className={styles.root}
                         onClick={(event) => setAnchor(undefined)}

--- a/packages/ui/react-ui/src/Button.tsx
+++ b/packages/ui/react-ui/src/Button.tsx
@@ -20,6 +20,7 @@ export const Button: FC<ButtonProps> = (props) => {
             onClick={props.onClick}
             style={{ justifyContent, ...props.style }}
             tabIndex={props.tabIndex || 0}
+            type="button"
         >
             {props.startIcon && <i className="wallet-adapter-button-start-icon">{props.startIcon}</i>}
             {props.children}

--- a/packages/ui/vue-ui/src/WalletButton.vue
+++ b/packages/ui/vue-ui/src/WalletButton.vue
@@ -12,7 +12,7 @@ export default defineComponent({
 </script>
 
 <template>
-    <button class="wallet-adapter-button" :style="`justify-content: ${justifyContent};`">
+    <button class="wallet-adapter-button" :style="`justify-content: ${justifyContent};`" type="button">
         <i v-if="$slots['start-icon']" className="wallet-adapter-button-start-icon">
             <slot name="start-icon"></slot>
         </i>


### PR DESCRIPTION
Hi there! I was starting to toy around with the React component for selecting a wallet and I love it! One thing that is causing me some trouble, though, is that if it is rendered inside a `<form />` tag, it actually submits the form on click! The recommended way to deal with this is to add `type="button"` to your `<button />` tag. More info on that here: https://stackoverflow.com/questions/2825856/html-button-to-not-submit-form.

So I've added it for the React and the Vue components. I'm not familiar with ant-design or material-ui myself, but it seems from my uninformed perspective that both of those components allow the passing of arbitrary props, so a user could probably handle this themselves if they were using those components.

Please let me know if there's anything else I have missed or you would like for me to add, and thank you for your time!