### PR TITLE
Detect ready wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,7 @@ yarn add @solana/wallet-adapter-base \
 import React, { FC, useMemo } from 'react';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
-import {
-    getLedgerWallet,
-    getPhantomWallet,
-    getSlopeWallet,
-    getSolflareWallet,
-    getSolletExtensionWallet,
-    getSolletWallet,
-    getTorusWallet,
-} from '@solana/wallet-adapter-wallets';
+import { getWallets } from '@solana/wallet-adapter-wallets';
 import {
     WalletModalProvider,
     WalletDisconnectButton,
@@ -73,17 +65,10 @@ export const Wallet: FC = () => {
     // You can also provide a custom RPC endpoint
     const endpoint = useMemo(() => clusterApiUrl(network), [network]);
 
-    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking --
-    // Only the wallets you configure here will be compiled into your application
-    const wallets = useMemo(() => [
-        getPhantomWallet(),
-        getSlopeWallet(),
-        getSolflareWallet(),
-        getTorusWallet(),
-        getLedgerWallet(),
-        getSolletWallet({ network }),
-        getSolletExtensionWallet({ network }),
-    ], [network]);
+    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
+    // Only the wallets you configure here will be compiled into your application, and only the dependencies
+    // of wallets that your users connect to will be loaded
+    const wallets = useMemo(() => getWallets({ network }), [network]);
 
     return (
         <ConnectionProvider endpoint={endpoint}>

--- a/packages/core/angular/src/wallet/wallet.store.ts
+++ b/packages/core/angular/src/wallet/wallet.store.ts
@@ -83,10 +83,10 @@ export class WalletStore extends ComponentStore<WalletState> {
 
     // Map of wallet names to wallets
     private readonly _walletsByName$ = this.select(this.wallets$, (wallets) =>
-        wallets.reduce((walletsByName, wallet) => {
+        wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
             walletsByName[wallet.name] = wallet;
             return walletsByName;
-        }, {} as { [name: WalletName]: Wallet })
+        }, {})
     );
 
     constructor(

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-react",
-    "version": "0.14.1",
+    "version": "0.14.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -8,18 +8,7 @@ import {
     WalletNotReadyError,
 } from '@solana/wallet-adapter-base';
 import { Connection, PublicKey, Transaction } from '@solana/web3.js';
-import React, {
-    DependencyList,
-    Dispatch,
-    FC,
-    ReactNode,
-    SetStateAction,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import React, { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { WalletNotSelectedError } from './errors';
 import { useInitialState } from './useInitialState';
 import { useLocalStorage } from './useLocalStorage';

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -43,6 +43,24 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     onError,
     localStorageKey = 'walletName',
 }) => {
+    const [name, setName] = useLocalStorage<WalletName | null>(localStorageKey, null);
+    const [{ wallet, adapter, ready, publicKey, connected }, setState] = useState(initialState);
+    const [connecting, setConnecting] = useState(false);
+    const [disconnecting, setDisconnecting] = useState(false);
+    const isConnecting = useRef(false);
+    const isDisconnecting = useRef(false);
+    const isUnloading = useRef(false);
+
+    // When the wallets change, map the wallet names to the wallets
+    const walletsByName = useMemo(
+        () =>
+            wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
+                walletsByName[wallet.name] = wallet;
+                return walletsByName;
+            }, {}),
+        [wallets]
+    );
+
     // When the wallets change, initialize the details
     const [details, setDetails] = useInitialState(
         () =>
@@ -68,25 +86,6 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             }
         })();
     }, [wallets]);
-
-    // When the wallets change, map the wallet names to the wallets
-    const walletsByName = useMemo(
-        () =>
-            wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
-                walletsByName[wallet.name] = wallet;
-                return walletsByName;
-            }, {}),
-        [wallets]
-    );
-
-    // Setup the rest of the state
-    const [name, setName] = useLocalStorage<WalletName | null>(localStorageKey, null);
-    const [{ wallet, adapter, ready, publicKey, connected }, setState] = useState(initialState);
-    const [connecting, setConnecting] = useState(false);
-    const [disconnecting, setDisconnecting] = useState(false);
-    const isConnecting = useRef(false);
-    const isDisconnecting = useRef(false);
-    const isUnloading = useRef(false);
 
     // When the selected wallet changes, initialize the state
     useEffect(() => {

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -12,7 +12,7 @@ import React, { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState
 import { WalletNotSelectedError } from './errors';
 import { useInitialState } from './useInitialState';
 import { useLocalStorage } from './useLocalStorage';
-import { WalletContext, WalletDetails } from './useWallet';
+import { EnhancedWallet, WalletContext } from './useWallet';
 
 export interface WalletProviderProps {
     children: ReactNode;
@@ -23,7 +23,7 @@ export interface WalletProviderProps {
 }
 
 const initialState: {
-    wallet: Wallet | null;
+    wallet: EnhancedWallet | null;
     adapter: Adapter | null;
     ready: boolean;
     connected: boolean;
@@ -32,8 +32,8 @@ const initialState: {
     wallet: null,
     adapter: null,
     ready: false,
-    publicKey: null,
     connected: false,
+    publicKey: null,
 };
 
 export const WalletProvider: FC<WalletProviderProps> = ({
@@ -51,66 +51,50 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     const isDisconnecting = useRef(false);
     const isUnloading = useRef(false);
 
-    // When the wallets change, map the wallet names to the wallets
-    const walletsByName = useMemo(
-        () =>
-            wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
-                walletsByName[wallet.name] = wallet;
-                return walletsByName;
-            }, {}),
+    // When the wallets change, enhance them with additional properties
+    const [enhancedWallets, setEnhancedWallets] = useInitialState(
+        () => wallets.map((wallet) => ({ ...wallet, ready: false })),
         [wallets]
     );
 
-    // When the wallets change, initialize the details
-    const [details, setDetails] = useInitialState(
-        () =>
-            wallets.reduce<Record<WalletName, WalletDetails>>((details, wallet) => {
-                details[wallet.name] = { ready: false };
-                return details;
-            }, {}),
-        [wallets]
-    );
-
-    // When the wallets change, asynchronously update the details
+    // When the wallets change, asynchronously update the enhanced properties
     useEffect(() => {
         (async () => {
             const waiting = wallets;
             const ready = await Promise.all(wallets.map((wallet) => wallet.adapter.ready()));
-            // If the wallets haven't changed while waiting, update the details
+            // If the wallets haven't changed while waiting, update the enhanced properties
             if (wallets === waiting) {
-                const details = wallets.reduce<Record<WalletName, WalletDetails>>((details, wallet, index) => {
-                    details[wallet.name] = { ready: ready[index] };
-                    return details;
-                }, {});
-                setDetails(details);
+                setEnhancedWallets(wallets.map((wallet, index) => ({ ...wallet, ready: ready[index] })));
             }
         })();
     }, [wallets]);
 
+    // When the enhanced wallets change, map the wallet names to the enhanced wallets
+    const enhancedWalletsByName = useMemo(
+        () =>
+            enhancedWallets.reduce<Record<WalletName, EnhancedWallet>>((enhancedWallets, enhancedWallet) => {
+                enhancedWallets[enhancedWallet.name] = enhancedWallet;
+                return enhancedWallets;
+            }, {}),
+        [enhancedWallets]
+    );
+
     // When the selected wallet changes, initialize the state
     useEffect(() => {
-        const wallet = (name && walletsByName[name]) || null;
+        const wallet = (name && enhancedWalletsByName[name]) || null;
         const adapter = wallet && wallet.adapter;
         if (adapter) {
-            const { publicKey, connected } = adapter;
-            const ready = (name && details[name]?.ready) || false;
-            setState({ wallet, adapter, connected, publicKey, ready });
-
-            // If the adapter isn't ready, asynchronously update the ready state
-            if (!ready) {
-                const waiting = name;
-                (async function () {
-                    const ready = await adapter.ready();
-                    // If the selected wallet hasn't changed while waiting, update the ready state
-                    if (name === waiting) {
-                        setState((state) => ({ ...state, ready }));
-                    }
-                })();
-            }
+            setState({
+                wallet,
+                adapter,
+                ready: enhancedWalletsByName[wallet.name].ready,
+                connected: adapter.connected,
+                publicKey: adapter.publicKey,
+            });
         } else {
             setState(initialState);
         }
-    }, [name, walletsByName, setState]);
+    }, [name, enhancedWalletsByName, setState]);
 
     // If autoConnect is enabled, try to connect when the adapter changes and is ready
     useEffect(() => {
@@ -155,9 +139,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     // Handle the adapter's connect event
     const handleConnect = useCallback(() => {
         if (!adapter) return;
-
-        const { connected, publicKey } = adapter;
-        setState((state) => ({ ...state, connected, publicKey }));
+        setState((state) => ({ ...state, connected: adapter.connected, publicKey: adapter.publicKey }));
     }, [adapter, setState]);
 
     // Handle the adapter's disconnect event
@@ -301,8 +283,8 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     return (
         <WalletContext.Provider
             value={{
-                wallets,
-                details,
+                wallets: enhancedWallets,
+                walletsByName: enhancedWalletsByName,
                 autoConnect,
                 wallet,
                 adapter,

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -53,10 +53,10 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     // Map of wallet names to wallets
     const walletsByName = useMemo(
         () =>
-            wallets.reduce((walletsByName, wallet) => {
+            wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
                 walletsByName[wallet.name] = wallet;
                 return walletsByName;
-            }, {} as { [name: WalletName]: Wallet }),
+            }, {}),
         [wallets]
     );
 

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -8,8 +8,20 @@ import {
     WalletNotReadyError,
 } from '@solana/wallet-adapter-base';
 import { Connection, PublicKey, Transaction } from '@solana/web3.js';
-import React, { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+    DependencyList,
+    Dispatch,
+    FC,
+    ReactNode,
+    SetStateAction,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { WalletNotSelectedError } from './errors';
+import { useInitialState } from './useInitialState';
 import { useLocalStorage } from './useLocalStorage';
 import { WalletContext, WalletDetails } from './useWallet';
 
@@ -42,12 +54,33 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     onError,
     localStorageKey = 'walletName',
 }) => {
-    const [details, setDetails] = useState(() =>
-        wallets.reduce<Record<WalletName, WalletDetails>>((details, wallet) => {
-            details[wallet.name] = { ready: false };
-            return details;
-        }, {})
+    // When the wallets change, initialize the details
+    const [details, setDetails] = useInitialState(
+        () =>
+            wallets.reduce<Record<WalletName, WalletDetails>>((details, wallet) => {
+                details[wallet.name] = { ready: false };
+                return details;
+            }, {}),
+        [wallets]
     );
+
+    // When the wallets change, asynchronously update the details
+    useEffect(() => {
+        (async () => {
+            const waiting = wallets;
+            const ready = await Promise.all(wallets.map((wallet) => wallet.adapter.ready()));
+            // If the wallets haven't changed while waiting, update the details
+            if (wallets === waiting) {
+                setDetails(
+                    wallets.reduce<Record<WalletName, WalletDetails>>((details, wallet, index) => {
+                        details[wallet.name] = { ready: ready[index] };
+                        return details;
+                    }, {})
+                );
+            }
+        })();
+    }, [wallets]);
+
     const [name, setName] = useLocalStorage<WalletName | null>(localStorageKey, null);
     const [{ wallet, adapter, ready, publicKey, connected }, setState] = useState(initialState);
     const [connecting, setConnecting] = useState(false);
@@ -65,23 +98,6 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             }, {}),
         [wallets]
     );
-
-    // When the wallets change, asynchronously derive the details
-    useEffect(() => {
-        (async () => {
-            const waiting = wallets;
-            const ready = await Promise.all(wallets.map((wallet) => wallet.adapter.ready()));
-            // If the wallets haven't changed while waiting, update the details state
-            if (wallets === waiting) {
-                setDetails(
-                    wallets.reduce<Record<WalletName, WalletDetails>>((details, wallet, index) => {
-                        details[wallet.name] = { ready: ready[index] };
-                        return details;
-                    }, {})
-                );
-            }
-        })();
-    }, [wallets]);
 
     // When the selected wallet changes, initialize the state
     useEffect(() => {

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -105,17 +105,20 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         const adapter = wallet && wallet.adapter;
         if (adapter) {
             const { publicKey, connected } = adapter;
-            setState({ wallet, adapter, connected, publicKey, ready: false });
+            const ready = (name && details[name]?.ready) || false;
+            setState({ wallet, adapter, connected, publicKey, ready });
 
-            // Asynchronously update the ready state
-            const waiting = name;
-            (async function () {
-                const ready = await adapter.ready();
-                // If the selected wallet hasn't changed while waiting, update the ready state
-                if (name === waiting) {
-                    setState((state) => ({ ...state, ready }));
-                }
-            })();
+            // If the adapter isn't ready, asynchronously update the ready state
+            if (!ready) {
+                const waiting = name;
+                (async function () {
+                    const ready = await adapter.ready();
+                    // If the selected wallet hasn't changed while waiting, update the ready state
+                    if (name === waiting) {
+                        setState((state) => ({ ...state, ready }));
+                    }
+                })();
+            }
         } else {
             setState(initialState);
         }

--- a/packages/core/react/src/useInitialState.ts
+++ b/packages/core/react/src/useInitialState.ts
@@ -1,0 +1,15 @@
+import { DependencyList, Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+
+/** @internal */
+export function useInitialState<S>(
+    factory: () => S,
+    deps: DependencyList | undefined
+): [S, Dispatch<SetStateAction<S>>] {
+    const initialState = useMemo(factory, deps);
+    const [state, setState] = useState(initialState);
+
+    // When the deps change, reinitialize the state
+    useEffect(() => setState(initialState), [initialState]);
+
+    return [state, setState];
+}

--- a/packages/core/react/src/useWallet.ts
+++ b/packages/core/react/src/useWallet.ts
@@ -8,8 +8,13 @@ import {
 } from '@solana/wallet-adapter-base';
 import { createContext, useContext } from 'react';
 
+export interface WalletDetails {
+    ready: boolean;
+}
+
 export interface WalletContextState extends Omit<WalletAdapterProps, 'ready'> {
     wallets: Wallet[];
+    details: Record<WalletName, WalletDetails>;
     autoConnect: boolean;
 
     wallet: Wallet | null;

--- a/packages/core/react/src/useWallet.ts
+++ b/packages/core/react/src/useWallet.ts
@@ -8,16 +8,15 @@ import {
 } from '@solana/wallet-adapter-base';
 import { createContext, useContext } from 'react';
 
-export interface WalletDetails {
+export interface EnhancedWallet extends Wallet {
     ready: boolean;
 }
 
 export interface WalletContextState extends Omit<WalletAdapterProps, 'ready'> {
-    wallets: Wallet[];
-    details: Record<WalletName, WalletDetails>;
+    wallets: EnhancedWallet[];
+    walletsByName: Record<WalletName, EnhancedWallet>;
     autoConnect: boolean;
-
-    wallet: Wallet | null;
+    wallet: EnhancedWallet | null;
     adapter: Adapter | null;
     ready: boolean;
     disconnecting: boolean;
@@ -26,7 +25,6 @@ export interface WalletContextState extends Omit<WalletAdapterProps, 'ready'> {
 
     signTransaction: SignerWalletAdapterProps['signTransaction'] | undefined;
     signAllTransactions: SignerWalletAdapterProps['signAllTransactions'] | undefined;
-
     signMessage: MessageSignerWalletAdapterProps['signMessage'] | undefined;
 }
 

--- a/packages/core/svelte/src/walletStore.ts
+++ b/packages/core/svelte/src/walletStore.ts
@@ -15,7 +15,6 @@ import { get, writable } from 'svelte/store';
 import { WalletNotSelectedError } from './errors';
 import { getLocalStorage, setLocalStorage } from './localStorage';
 
-type WalletDictionary = { [walletName: WalletName]: Wallet };
 type ErrorHandler = (error: WalletError) => void;
 type WalletConfig = Pick<WalletStore, 'wallets' | 'autoConnect' | 'localStorageKey' | 'onError'>;
 type WalletStatus = Pick<WalletStore, 'connected' | 'publicKey'>;
@@ -33,7 +32,7 @@ interface WalletStore {
     publicKey: PublicKey | null;
     ready: boolean;
     wallet: Wallet | null;
-    walletsByName: WalletDictionary;
+    walletsByName: Record<WalletName, Wallet>;
     name: WalletName | null;
 
     connect(): Promise<void>;
@@ -115,7 +114,7 @@ function createWalletStore() {
         ready: false,
         wallet: null,
         name: null,
-        walletsByName: {} as WalletDictionary,
+        walletsByName: {},
         connect,
         disconnect,
         select,
@@ -213,7 +212,7 @@ function createWalletStore() {
         setDisconnecting: (disconnecting: boolean) => update((store) => ({ ...store, disconnecting })),
         setReady: (ready: boolean) => update((store) => ({ ...store, ready })),
         subscribe,
-        updateConfig: (walletConfig: WalletConfig & { walletsByName: WalletDictionary }) =>
+        updateConfig: (walletConfig: WalletConfig & { walletsByName: Record<WalletName, Wallet> }) =>
             update((store) => ({
                 ...store,
                 ...walletConfig,
@@ -244,10 +243,10 @@ export async function initialize({
     localStorageKey = 'walletAdapter',
     onError = (error: WalletError) => console.error(error),
 }: WalletConfig): Promise<void> {
-    const walletsByName = wallets.reduce((walletsByName, wallet) => {
+    const walletsByName = wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
         walletsByName[wallet.name] = wallet;
         return walletsByName;
-    }, {} as WalletDictionary);
+    }, {});
 
     walletStore.updateConfig({
         wallets,

--- a/packages/core/vue/src/useWallet.ts
+++ b/packages/core/vue/src/useWallet.ts
@@ -14,8 +14,6 @@ import { computed, inject, InjectionKey, provide, Ref, ref, watch, watchEffect }
 import { WalletNotSelectedError } from './errors';
 import { useLocalStorage } from './useLocalStorage';
 
-type WalletDictionary = { [walletName: WalletName]: Wallet };
-
 export interface WalletStore {
     // Props.
     wallets: Wallet[];
@@ -110,11 +108,11 @@ export const createWalletStore = ({
     };
 
     // Create a wallet dictionary keyed by their name.
-    const walletsByName = computed<WalletDictionary>(() => {
-        return wallets.reduce((walletsByName, wallet) => {
+    const walletsByName = computed(() => {
+        return wallets.reduce<Record<WalletName, Wallet>>((walletsByName, wallet) => {
             walletsByName[wallet.name] = wallet;
             return walletsByName;
-        }, {} as WalletDictionary);
+        }, {});
     });
 
     // Update the wallet and adapter based on the wallet provider.

--- a/packages/starter/example/components/ContextProvider.tsx
+++ b/packages/starter/example/components/ContextProvider.tsx
@@ -3,15 +3,7 @@ import deepPurple from '@material-ui/core/colors/deepPurple';
 import pink from '@material-ui/core/colors/pink';
 import { WalletAdapterNetwork, WalletError } from '@solana/wallet-adapter-base';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
-import {
-    getLedgerWallet,
-    getPhantomWallet,
-    getSlopeWallet,
-    getSolflareWallet,
-    getSolletExtensionWallet,
-    getSolletWallet,
-    getTorusWallet,
-} from '@solana/wallet-adapter-wallets';
+import { getWallets } from '@solana/wallet-adapter-wallets';
 import { clusterApiUrl } from '@solana/web3.js';
 import { SnackbarProvider, useSnackbar } from 'notistack';
 import { FC, ReactNode, useCallback, useMemo } from 'react';
@@ -49,22 +41,18 @@ const theme = createTheme({
 });
 
 const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
-    const network = WalletAdapterNetwork.Devnet;
-    const endpoint = useMemo(() => clusterApiUrl(network), [network]);
     const { autoConnect } = useAutoConnect();
 
-    const wallets = useMemo(
-        () => [
-            getPhantomWallet(),
-            getSlopeWallet(),
-            getSolflareWallet(),
-            getTorusWallet(),
-            getLedgerWallet(),
-            getSolletWallet({ network }),
-            getSolletExtensionWallet({ network }),
-        ],
-        [network]
-    );
+    // Can be set to 'devnet', 'testnet', or 'mainnet-beta'
+    const network = WalletAdapterNetwork.Devnet;
+
+    // You can also provide a custom RPC endpoint
+    const endpoint = useMemo(() => clusterApiUrl(network), [network]);
+
+    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
+    // Only the wallets you configure here will be compiled into your application, and only the dependencies
+    // of wallets that your users connect to will be loaded
+    const wallets = useMemo(() => getWallets({ network }), [network]);
 
     const { enqueueSnackbar } = useSnackbar();
     const onError = useCallback(

--- a/packages/starter/example/package.json
+++ b/packages/starter/example/package.json
@@ -35,7 +35,7 @@
         "@solana/wallet-adapter-material-ui": "^0.14.0",
         "@solana/wallet-adapter-react": "^0.14.0",
         "@solana/wallet-adapter-react-ui": "^0.7.0",
-        "@solana/wallet-adapter-wallets": "^0.13.0",
+        "@solana/wallet-adapter-wallets": "^0.13.1",
         "@solana/web3.js": "^1.20.0",
         "antd": "^4.16.11",
         "bs58": "^4.0.1",

--- a/packages/starter/material-ui-starter/package.json
+++ b/packages/starter/material-ui-starter/package.json
@@ -30,7 +30,7 @@
         "@solana/wallet-adapter-base": "^0.8.1",
         "@solana/wallet-adapter-material-ui": "^0.14.0",
         "@solana/wallet-adapter-react": "^0.14.0",
-        "@solana/wallet-adapter-wallets": "^0.13.0",
+        "@solana/wallet-adapter-wallets": "^0.13.1",
         "@solana/web3.js": "^1.20.0",
         "notistack": "^1.0.9",
         "react": "^17.0.2",

--- a/packages/starter/material-ui-starter/src/Wallet.tsx
+++ b/packages/starter/material-ui-starter/src/Wallet.tsx
@@ -1,38 +1,23 @@
 import { WalletAdapterNetwork, WalletError } from '@solana/wallet-adapter-base';
 import { WalletDialogProvider } from '@solana/wallet-adapter-material-ui';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
-import {
-    getLedgerWallet,
-    getPhantomWallet,
-    getSlopeWallet,
-    getSolflareWallet,
-    getSolletExtensionWallet,
-    getSolletWallet,
-    getTorusWallet,
-} from '@solana/wallet-adapter-wallets';
+import { getWallets } from '@solana/wallet-adapter-wallets';
 import { clusterApiUrl } from '@solana/web3.js';
 import { useSnackbar } from 'notistack';
 import React, { FC, useCallback, useMemo } from 'react';
 import { Navigation } from './Navigation';
 
 export const Wallet: FC = () => {
+    // Can be set to 'devnet', 'testnet', or 'mainnet-beta'
     const network = WalletAdapterNetwork.Devnet;
+
+    // You can also provide a custom RPC endpoint
     const endpoint = useMemo(() => clusterApiUrl(network), [network]);
 
-    // @solana/wallet-adapter-wallets imports all the adapters but supports tree shaking --
-    // Only the wallets you want to support will be compiled into your application
-    const wallets = useMemo(
-        () => [
-            getPhantomWallet(),
-            getSlopeWallet(),
-            getSolflareWallet(),
-            getTorusWallet(),
-            getLedgerWallet(),
-            getSolletWallet({ network }),
-            getSolletExtensionWallet({ network }),
-        ],
-        [network]
-    );
+    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
+    // Only the wallets you configure here will be compiled into your application, and only the dependencies
+    // of wallets that your users connect to will be loaded
+    const wallets = useMemo(() => getWallets({ network }), [network]);
 
     const { enqueueSnackbar } = useSnackbar();
     const onError = useCallback(

--- a/packages/starter/nextjs-starter/components/WalletConnectionProvider.tsx
+++ b/packages/starter/nextjs-starter/components/WalletConnectionProvider.tsx
@@ -1,14 +1,6 @@
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
-import {
-    getLedgerWallet,
-    getPhantomWallet,
-    getSlopeWallet,
-    getSolflareWallet,
-    getSolletExtensionWallet,
-    getSolletWallet,
-    getTorusWallet,
-} from '@solana/wallet-adapter-wallets';
+import { getWallets } from '@solana/wallet-adapter-wallets';
 import { clusterApiUrl } from '@solana/web3.js';
 import { FC, ReactNode, useMemo } from 'react';
 
@@ -19,20 +11,10 @@ export const WalletConnectionProvider: FC<{ children: ReactNode }> = ({ children
     // You can also provide a custom RPC endpoint
     const endpoint = useMemo(() => clusterApiUrl(network), [network]);
 
-    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking --
-    // Only the wallets you configure here will be compiled into your application
-    const wallets = useMemo(
-        () => [
-            getPhantomWallet(),
-            getSlopeWallet(),
-            getSolflareWallet(),
-            getTorusWallet(),
-            getLedgerWallet(),
-            getSolletWallet({ network }),
-            getSolletExtensionWallet({ network }),
-        ],
-        [network]
-    );
+    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
+    // Only the wallets you configure here will be compiled into your application, and only the dependencies
+    // of wallets that your users connect to will be loaded
+    const wallets = useMemo(() => getWallets({ network }), [network]);
 
     return (
         <ConnectionProvider endpoint={endpoint}>

--- a/packages/starter/nextjs-starter/package.json
+++ b/packages/starter/nextjs-starter/package.json
@@ -30,7 +30,7 @@
         "@solana/wallet-adapter-base": "^0.8.1",
         "@solana/wallet-adapter-react": "^0.14.0",
         "@solana/wallet-adapter-react-ui": "^0.7.0",
-        "@solana/wallet-adapter-wallets": "^0.13.0",
+        "@solana/wallet-adapter-wallets": "^0.13.1",
         "@solana/web3.js": "^1.20.0",
         "next": "^11.1.2",
         "react": "^17.0.2",

--- a/packages/starter/react-ui-starter/package.json
+++ b/packages/starter/react-ui-starter/package.json
@@ -28,7 +28,7 @@
         "@solana/wallet-adapter-base": "^0.8.1",
         "@solana/wallet-adapter-react": "^0.14.0",
         "@solana/wallet-adapter-react-ui": "^0.7.0",
-        "@solana/wallet-adapter-wallets": "^0.13.0",
+        "@solana/wallet-adapter-wallets": "^0.13.1",
         "@solana/web3.js": "^1.20.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/packages/starter/react-ui-starter/src/Wallet.tsx
+++ b/packages/starter/react-ui-starter/src/Wallet.tsx
@@ -1,15 +1,7 @@
 import { WalletAdapterNetwork, WalletError } from '@solana/wallet-adapter-base';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
-import {
-    getLedgerWallet,
-    getPhantomWallet,
-    getSlopeWallet,
-    getSolflareWallet,
-    getSolletExtensionWallet,
-    getSolletWallet,
-    getTorusWallet,
-} from '@solana/wallet-adapter-wallets';
+import { getWallets } from '@solana/wallet-adapter-wallets';
 import { clusterApiUrl } from '@solana/web3.js';
 import React, { FC, useCallback, useMemo } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
@@ -17,23 +9,16 @@ import { Navigation } from './Navigation';
 import { Notification } from './Notification';
 
 export const Wallet: FC = () => {
+    // Can be set to 'devnet', 'testnet', or 'mainnet-beta'
     const network = WalletAdapterNetwork.Devnet;
+
+    // You can also provide a custom RPC endpoint
     const endpoint = useMemo(() => clusterApiUrl(network), [network]);
 
-    // @solana/wallet-adapter-wallets imports all the adapters but supports tree shaking --
-    // Only the wallets you want to support will be compiled into your application
-    const wallets = useMemo(
-        () => [
-            getPhantomWallet(),
-            getSlopeWallet(),
-            getSolflareWallet(),
-            getTorusWallet(),
-            getLedgerWallet(),
-            getSolletWallet({ network }),
-            getSolletExtensionWallet({ network }),
-        ],
-        [network]
-    );
+    // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
+    // Only the wallets you configure here will be compiled into your application, and only the dependencies
+    // of wallets that your users connect to will be loaded
+    const wallets = useMemo(() => getWallets({ network }), [network]);
 
     const onError = useCallback(
         (error: WalletError) =>

--- a/packages/wallets/wallets/package.json
+++ b/packages/wallets/wallets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-wallets",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/wallets/wallets/src/index.ts
+++ b/packages/wallets/wallets/src/index.ts
@@ -14,3 +14,4 @@ export * from '@solana/wallet-adapter-sollet';
 export * from '@solana/wallet-adapter-solong';
 export * from '@solana/wallet-adapter-tokenpocket';
 export * from '@solana/wallet-adapter-torus';
+export * from './wallets';

--- a/packages/wallets/wallets/src/wallets.ts
+++ b/packages/wallets/wallets/src/wallets.ts
@@ -1,0 +1,46 @@
+import { Wallet, WalletAdapterNetwork } from '@solana/wallet-adapter-base';
+import { getBitKeepWallet } from '@solana/wallet-adapter-bitkeep';
+import { getBitpieWallet } from '@solana/wallet-adapter-bitpie';
+import { getBloctoWallet } from '@solana/wallet-adapter-blocto';
+import { getCloverWallet } from '@solana/wallet-adapter-clover';
+import { getCoin98Wallet } from '@solana/wallet-adapter-coin98';
+import { getCoinhubWallet } from '@solana/wallet-adapter-coinhub';
+import { getLedgerWallet } from '@solana/wallet-adapter-ledger';
+import { getMathWallet } from '@solana/wallet-adapter-mathwallet';
+import { getPhantomWallet } from '@solana/wallet-adapter-phantom';
+import { getSafePalWallet } from '@solana/wallet-adapter-safepal';
+import { getSlopeWallet } from '@solana/wallet-adapter-slope';
+import { getSolflareWallet } from '@solana/wallet-adapter-solflare';
+import { getSolflareWebWallet, getSolletExtensionWallet, getSolletWallet } from '@solana/wallet-adapter-sollet';
+import { getSolongWallet } from '@solana/wallet-adapter-solong';
+import { getTokenPocketWallet } from '@solana/wallet-adapter-tokenpocket';
+import { getTorusWallet } from '@solana/wallet-adapter-torus';
+
+export interface WalletsConfig {
+    network?: WalletAdapterNetwork;
+}
+
+export function getWallets({ network = WalletAdapterNetwork.Mainnet }: WalletsConfig = {}): Wallet[] {
+    return [
+        getPhantomWallet(),
+        getSlopeWallet(),
+        getSolflareWallet(),
+        getSolletExtensionWallet({ network }),
+
+        getBitKeepWallet(),
+        getBitpieWallet(),
+        getCloverWallet(),
+        getCoin98Wallet(),
+        getCoinhubWallet(),
+        getMathWallet(),
+        getSafePalWallet(),
+        getSolongWallet(),
+        getTokenPocketWallet(),
+
+        getTorusWallet({ params: { showTorusButton: false } }),
+        getLedgerWallet(),
+        getSolletWallet({ network }),
+        getSolflareWebWallet({ network }),
+        getBloctoWallet({ network }),
+    ];
+}


### PR DESCRIPTION
Partially implements #201 (it detects, but doesn't filter)

Filtering of the wallets shouldn't be done in the React context necessarily -- it may be better to handle this in UI components where it can be done more flexibly rather than just removing them from the list.