### PR TITLE
fix(svelte core): autoconnect

### DIFF
--- a/packages/core/svelte/src/walletStore.ts
+++ b/packages/core/svelte/src/walletStore.ts
@@ -148,6 +148,10 @@ function createWalletStore() {
                     ...store,
                     ready,
                 }));
+
+                if (shouldAutoConnect()) {
+                    autoConnect();
+                }
             }
         })();
     }
@@ -201,10 +205,6 @@ function createWalletStore() {
         }
 
         update((store) => ({ ...store, adapter, signTransaction, signAllTransactions, signMessage }));
-
-        if (shouldAutoConnect()) {
-            autoConnect();
-        }
     }
 
     return {


### PR DESCRIPTION
autoconnect only needs to run if the adapter is ready