### PR TITLE
[fix] The state initialization effect will no longer run if the wallet list has changed

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -59,14 +59,16 @@ export const WalletProvider: FC<WalletProviderProps> = ({
 
     // When the wallets change, asynchronously update the enhanced properties
     useEffect(() => {
+        let walletsChangedWhileWaiting = false;
         (async () => {
-            const waiting = wallets;
             const ready = await Promise.all(wallets.map((wallet) => wallet.adapter.ready()));
-            // If the wallets haven't changed while waiting, update the enhanced properties
-            if (wallets === waiting) {
+            if (!walletsChangedWhileWaiting) {
                 setEnhancedWallets(wallets.map((wallet, index) => ({ ...wallet, ready: ready[index] })));
             }
         })();
+        return () => {
+            walletsChangedWhileWaiting = true;
+        };
     }, [wallets]);
 
     // When the enhanced wallets change, map the wallet names to the enhanced wallets


### PR DESCRIPTION
Because we await a series of promises in this effect, an effort was made to _prevent_ the state from being set if the list of wallets happens to change while the promise was in flight.

Because of the way that bindings work in React, though, this didn't accomplish what we hoped. The `wallets === waiting` test would _always_ pass because the `wallets` binding is immutable for the life of that effect.

What we can do instead is to track wether the effect was ever invalidated by hooking into its teardown. If it has, we can skip setting the enhanced wallets because one of two things have happened.

1. We're unmounting.
2. `wallets` changed so we'll be called again.