### PR TITLE
[tidy] Remove state setters from dependency arrays

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -96,7 +96,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         } else {
             setState(initialState);
         }
-    }, [name, enhancedWalletsByName, setState]);
+    }, [name, enhancedWalletsByName]);
 
     // If autoConnect is enabled, try to connect when the adapter changes and is ready
     useEffect(() => {
@@ -116,7 +116,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
                 isConnecting.current = false;
             }
         })();
-    }, [isConnecting, connecting, connected, autoConnect, adapter, ready, setConnecting, setName]);
+    }, [isConnecting, connecting, connected, autoConnect, adapter, ready]);
 
     // If the window is closing or reloading, ignore disconnect and error events from the adapter
     useEffect(() => {
@@ -135,20 +135,20 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             if (adapter) await adapter.disconnect();
             setName(walletName);
         },
-        [name, adapter, setName]
+        [name, adapter]
     );
 
     // Handle the adapter's connect event
     const handleConnect = useCallback(() => {
         if (!adapter) return;
         setState((state) => ({ ...state, connected: adapter.connected, publicKey: adapter.publicKey }));
-    }, [adapter, setState]);
+    }, [adapter]);
 
     // Handle the adapter's disconnect event
     const handleDisconnect = useCallback(() => {
         // Clear the selected wallet unless the window is unloading
         if (!isUnloading.current) setName(null);
-    }, [isUnloading, setName]);
+    }, [isUnloading]);
 
     // Handle the adapter's error event, and local errors
     const handleError = useCallback(
@@ -189,18 +189,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             setConnecting(false);
             isConnecting.current = false;
         }
-    }, [
-        isConnecting,
-        connecting,
-        disconnecting,
-        connected,
-        wallet,
-        adapter,
-        handleError,
-        ready,
-        setConnecting,
-        setName,
-    ]);
+    }, [isConnecting, connecting, disconnecting, connected, wallet, adapter, handleError, ready]);
 
     // Disconnect the adapter from the wallet
     const disconnect = useCallback(async () => {
@@ -220,7 +209,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             setDisconnecting(false);
             isDisconnecting.current = false;
         }
-    }, [isDisconnecting, disconnecting, adapter, setDisconnecting, setName]);
+    }, [isDisconnecting, disconnecting, adapter]);
 
     // Send a transaction using the provided connection
     const sendTransaction = useCallback(

--- a/packages/core/react/src/useLocalStorage.ts
+++ b/packages/core/react/src/useLocalStorage.ts
@@ -27,7 +27,7 @@ export function useLocalStorage<T>(key: string, defaultState: T): [T, (newValue:
                 console.error(error);
             }
         },
-        [value, setValue, key]
+        [value, key]
     );
 
     return [value, setLocalStorage];

--- a/packages/ui/react-ui/src/WalletModal.tsx
+++ b/packages/ui/react-ui/src/WalletModal.tsx
@@ -35,7 +35,7 @@ export const WalletModal: FC<WalletModalProps> = ({
     const hideModal = useCallback(() => {
         setFadeIn(false);
         setTimeout(() => setVisible(false), 150);
-    }, [setFadeIn, setVisible]);
+    }, []);
 
     const handleClose = useCallback(
         (event: MouseEvent) => {
@@ -53,7 +53,9 @@ export const WalletModal: FC<WalletModalProps> = ({
         [select, handleClose]
     );
 
-    const handleCollapseClick = useCallback(() => setExpanded(!expanded), [setExpanded, expanded]);
+    const handleCollapseClick = useCallback(() => {
+        setExpanded(!expanded);
+    }, [expanded]);
 
     const handleTabKey = useCallback(
         (event: KeyboardEvent) => {
@@ -107,7 +109,9 @@ export const WalletModal: FC<WalletModalProps> = ({
         };
     }, [hideModal, handleTabKey]);
 
-    useLayoutEffect(() => setPortal(document.querySelector(container)), [setPortal, container]);
+    useLayoutEffect(() => {
+        setPortal(document.querySelector(container));
+    }, [container]);
 
     return (
         portal &&

--- a/packages/ui/react-ui/src/WalletModalButton.tsx
+++ b/packages/ui/react-ui/src/WalletModalButton.tsx
@@ -10,7 +10,7 @@ export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet',
             if (onClick) onClick(event);
             if (!event.defaultPrevented) setVisible(!visible);
         },
-        [onClick, setVisible, visible]
+        [onClick, visible]
     );
 
     return (

--- a/packages/ui/react-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/react-ui/src/WalletMultiButton.tsx
@@ -28,14 +28,18 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
         }
     }, [base58]);
 
-    const openDropdown = useCallback(() => setActive(true), [setActive]);
+    const openDropdown = useCallback(() => {
+        setActive(true);
+    }, []);
 
-    const closeDropdown = useCallback(() => setActive(false), [setActive]);
+    const closeDropdown = useCallback(() => {
+        setActive(false);
+    }, []);
 
     const openModal = useCallback(() => {
         setVisible(true);
         closeDropdown();
-    }, [setVisible, closeDropdown]);
+    }, [closeDropdown]);
 
     useEffect(() => {
         const listener = (event: MouseEvent | TouchEvent) => {


### PR DESCRIPTION
In React, state setters are always guaranteed to be stable. The docs recommend omitting them from hook dependencies.

> React guarantees that setState function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency list.

https://reactjs.org/docs/hooks-reference.html#usestate

Eventually, we should install the `rules-of-hooks` and `exhaustive-deps` linters to catch things like this!

https://reactjs.org/docs/hooks-rules.html