### PR TITLE
[enhancement] The setter in `useLocalStorage` is now stable across renders

### DIFF
--- a/packages/core/react/src/__tests__/useLocalStorage-test.tsx
+++ b/packages/core/react/src/__tests__/useLocalStorage-test.tsx
@@ -171,6 +171,25 @@ describe('useLocalStorage', () => {
                 });
                 expect(ref.current?.getPersistedValue()).toBe(NEW_VALUE);
             });
+            describe('many times in a row', () => {
+                it('sets the new value in local storage once', () => {
+                    act(() => {
+                        ref.current?.persistValue(NEW_VALUE);
+                        ref.current?.persistValue(NEW_VALUE);
+                    });
+                    expect(window.localStorage.setItem).toHaveBeenCalledTimes(1);
+                    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, JSON.stringify(NEW_VALUE));
+                });
+            });
+            describe('multiple times ending with the current value', () => {
+                it("does not call local storage's setter", () => {
+                    act(() => {
+                        ref.current?.persistValue(NEW_VALUE);
+                        ref.current?.persistValue(DEFAULT_VALUE);
+                    });
+                    expect(window.localStorage.setItem).toHaveBeenCalledTimes(0);
+                });
+            });
         });
         describe('when setting to `null`', () => {
             beforeEach(() => {

--- a/packages/core/react/src/useLocalStorage.ts
+++ b/packages/core/react/src/useLocalStorage.ts
@@ -1,7 +1,7 @@
-import { useCallback, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-export function useLocalStorage<T>(key: string, defaultState: T): [T, (newValue: T) => void] {
-    const [value, setValue] = useState<T>(() => {
+export function useLocalStorage<T>(key: string, defaultState: T): [T, React.Dispatch<React.SetStateAction<T>>] {
+    const state = useState<T>(() => {
         try {
             const value = localStorage.getItem(key);
             if (value) return JSON.parse(value) as T;
@@ -12,23 +12,22 @@ export function useLocalStorage<T>(key: string, defaultState: T): [T, (newValue:
         return defaultState;
     });
 
-    const setLocalStorage = useCallback(
-        (newValue: T) => {
-            if (newValue === value) return;
-            setValue(newValue);
-
-            try {
-                if (newValue === null) {
-                    localStorage.removeItem(key);
-                } else {
-                    localStorage.setItem(key, JSON.stringify(newValue));
-                }
-            } catch (error) {
-                console.error(error);
+    const isFirstRender = useRef(true);
+    useEffect(() => {
+        if (isFirstRender.current === true) {
+            isFirstRender.current = false;
+            return;
+        }
+        try {
+            if (state[0] === null) {
+                localStorage.removeItem(key);
+            } else {
+                localStorage.setItem(key, JSON.stringify(state[0]));
             }
-        },
-        [value, setValue, key]
-    );
+        } catch (error) {
+            console.error(error);
+        }
+    }, [state[0]]);
 
-    return [value, setLocalStorage];
+    return state;
 }


### PR DESCRIPTION
Typically, state setters are stable across renders in React. This means, among other things, that you don't need to include them as a hook dependency (eg. to `useEffect` or `useMemo`).

> React guarantees that setState function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency list. – https://reactjs.org/docs/hooks-reference.html#usestate

I got into a little trouble in #216 because I assumed this to be the case for the state setter returned by our custom  `useLocalStorage` hook. This was not the case; it changed every time that the value or key changed.

In this PR, we refactor `useLocalStorage` so that the state setter _is_ stable across renders. This should make things more efficient overall, and prevent folks from making the same mistake I made above.

```
# Tests still pass after the refactor.
(cd packages/core/react; yarn test)
```