### PR TITLE
Alias select to setName

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -128,15 +128,6 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         return () => window.removeEventListener('beforeunload', listener);
     }, [isUnloading]);
 
-    // Select a wallet by name
-    const select = useCallback(
-        async (walletName: WalletName | null) => {
-            if (name === walletName) return;
-            setName(walletName);
-        },
-        [name]
-    );
-
     // Handle the adapter's connect event
     const handleConnect = useCallback(() => {
         if (!adapter) return;
@@ -290,7 +281,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
                 connected,
                 connecting,
                 disconnecting,
-                select,
+                select: setName,
                 connect,
                 disconnect,
                 sendTransaction,


### PR DESCRIPTION
Thanks to https://github.com/solana-labs/wallet-adapter/pull/222, `setName` is now stable across renders, and we can just alias `select` to it.