### PR TITLE
Fix ERR_UNSUPPORTED_DIR_IMPORT when using material UI

### DIFF
--- a/packages/ui/material-ui/src/WalletDialog.tsx
+++ b/packages/ui/material-ui/src/WalletDialog.tsx
@@ -11,7 +11,7 @@ import {
     ListItem,
     Theme,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled } from '@mui/material';
 import { WalletName } from '@solana/wallet-adapter-base';
 import { useWallet } from '@solana/wallet-adapter-react';
 import React, { FC, ReactElement, SyntheticEvent, useCallback, useMemo, useState } from 'react';

--- a/packages/ui/material-ui/src/WalletIcon.tsx
+++ b/packages/ui/material-ui/src/WalletIcon.tsx
@@ -1,5 +1,5 @@
 import { Theme } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled } from '@mui/material';
 import { Wallet } from '@solana/wallet-adapter-react';
 import React, { DetailedHTMLProps, FC, ImgHTMLAttributes } from 'react';
 

--- a/packages/ui/material-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/material-ui/src/WalletMultiButton.tsx
@@ -1,6 +1,6 @@
 import { FileCopy as CopyIcon, LinkOff as DisconnectIcon, SwapHoriz as SwitchIcon } from '@mui/icons-material';
 import { Button, ButtonProps, Collapse, Fade, ListItemIcon, Menu, MenuItem, Theme } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled } from '@mui/material';
 import { useWallet } from '@solana/wallet-adapter-react';
 import React, { FC, useMemo, useState } from 'react';
 import { useWalletDialog } from './useWalletDialog';


### PR DESCRIPTION
Hi all, if this isn't an issue and it's just a me problem, feel free to close this.

That said I tried to use the Next.js starter except swapping React UI for Material UI but kept running into an ERR_UNSUPPORTED_DIR_IMPORT error which pointed to these lines:

```
import { styled } from '@mui/material/styles';
```

The fix was to import from the base directory. I believe alternatively you can append the file extension.
