### PR TITLE
Updated wallet-adapter-vue to use the newest versions of its dependencies.

### DIFF
--- a/packages/core/vue/package.json
+++ b/packages/core/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-vue",
-    "version": "0.4.4",
+    "version": "0.5.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -27,11 +27,17 @@
         "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json"
     },
     "peerDependencies": {
-        "@solana/wallet-adapter-wallets": "^0.13.0"
+        "@solana/wallet-adapter-wallets": "^0.14.2"
     },
     "dependencies": {
-        "@solana/wallet-adapter-base": "^0.8.1",
+        "@solana/wallet-adapter-base": "^0.9.2",
         "@solana/web3.js": "^1.20.0",
         "vue": "^3.0.0"
+    },
+    "devDependencies": {
+        "@babel/types": "^7.16.8",
+        "@digitak/tsc-esm": "3.0.2",
+        "shx": "^0.3.4",
+        "tsc-esm-fix": "^2.7.6"
     }
 }

--- a/packages/core/vue/src/WalletProvider.ts
+++ b/packages/core/vue/src/WalletProvider.ts
@@ -1,12 +1,12 @@
-import { Wallet, WalletError } from '@solana/wallet-adapter-base';
-import { defineComponent, PropType } from '@vue/runtime-core';
+import { WalletAdapter, WalletError } from '@solana/wallet-adapter-base';
+import { defineComponent, PropType } from 'vue';
 import { provideWallet } from './useWallet';
 
 export const WalletProvider = defineComponent({
     name: 'wallet-provider',
     props: {
         wallets: {
-            type: Array as PropType<Wallet[]>,
+            type: Array as PropType<WalletAdapter[]>,
             default: () => [],
         },
         autoConnect: {


### PR DESCRIPTION
The code was using [@solana/wallet-adapter-wallets@0.13.1 ](https://github.com/solana-labs/wallet-adapter/blob/809ce18a2be4ef96c79bb3331386638efa6f17d9/packages/wallets/wallets/package.json) which seems to have never been published (the code was using references to 'Wallet' [which could be retrieved using getWallets in that version](https://github.com/solana-labs/wallet-adapter/blob/809ce18a2be4ef96c79bb3331386638efa6f17d9/packages/wallets/wallets/src/wallets.ts)), so I changed it to use the newest version of its dependencies. I also changed references to @vue/runtime-core to point to vue.

More context in #256 