### PR TITLE
Prevent CSS from getting tree-shaken by Parcel in production build

### DIFF
--- a/packages/starter/react-ui-starter/src/App.tsx
+++ b/packages/starter/react-ui-starter/src/App.tsx
@@ -13,9 +13,6 @@ import {
 import { clusterApiUrl } from '@solana/web3.js';
 import React, { FC, ReactNode, useMemo } from 'react';
 
-// Default styles that can be overridden by your app
-require('@solana/wallet-adapter-react-ui/styles.css');
-
 export const App: FC = () => {
     return (
         <Context>

--- a/packages/starter/react-ui-starter/src/index.html
+++ b/packages/starter/react-ui-starter/src/index.html
@@ -5,6 +5,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>WalletAdapter Starter</title>
         <link rel="stylesheet" href="index.css" />
+        <!-- Default styles that can be overridden by your app -->
+        <link rel="stylesheet" href="npm:@solana/wallet-adapter-react-ui/styles.css" />
     </head>
     <body>
         <div id="app"></div>


### PR DESCRIPTION
Fixes #269.

Parcel really liked tree-shaking the hell out of the CSS, since the CSS was imported as a side-effect in `App.tsx` without being referenced in code.

Importing it in the HTML prevents this.

## Test plan:

```
cd packages/starter/react-ui-starter
yarn start # Dev mode works
yarn build # Prod build works
(cd dist && python -m SimpleHTTPServer) # Load it... click the button.
```