### PR TITLE
Revert "Polyfill Node APIs for compatibility with Webpack 5 and Create React App 5"

### DIFF
--- a/packages/wallets/ledger/package.json
+++ b/packages/wallets/ledger/package.json
@@ -27,7 +27,6 @@
         "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json"
     },
     "dependencies": {
-        "buffer": "npm:buffer-browserify@^0.2.5",
         "@ledgerhq/hw-transport": "^6.11.2",
         "@ledgerhq/hw-transport-webhid": "^6.11.2",
         "@solana/wallet-adapter-base": "^0.9.1",

--- a/packages/wallets/ledger/src/adapter.ts
+++ b/packages/wallets/ledger/src/adapter.ts
@@ -1,5 +1,3 @@
-import './polyfills/index';
-
 import type Transport from '@ledgerhq/hw-transport';
 import {
     Adapter,

--- a/packages/wallets/ledger/src/polyfills/Buffer.ts
+++ b/packages/wallets/ledger/src/polyfills/Buffer.ts
@@ -1,7 +1,0 @@
-import { Buffer } from 'buffer';
-
-if (typeof window !== 'undefined' && window.Buffer === undefined) {
-    (window as any).Buffer = Buffer;
-}
-
-export {};

--- a/packages/wallets/ledger/src/polyfills/index.ts
+++ b/packages/wallets/ledger/src/polyfills/index.ts
@@ -1,3 +1,0 @@
-'use strict';
-
-import './Buffer';

--- a/packages/wallets/ledger/src/util.ts
+++ b/packages/wallets/ledger/src/util.ts
@@ -1,5 +1,3 @@
-import './polyfills/index';
-
 import Transport, { StatusCodes, TransportStatusError } from '@ledgerhq/hw-transport';
 import { PublicKey, Transaction } from '@solana/web3.js';
 

--- a/packages/wallets/torus/package.json
+++ b/packages/wallets/torus/package.json
@@ -27,10 +27,8 @@
         "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json"
     },
     "dependencies": {
-        "assert": "npm:assert@^2.0.0",
         "@solana/wallet-adapter-base": "^0.9.1",
         "@solana/web3.js": "^1.20.0",
-        "stream": "npm:stream-browserify@^3.0.0",
         "@toruslabs/solana-embed": "^0.0.9",
         "@types/keccak": "^3.0.1",
         "@types/readable-stream": "^2.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5348,9 +5348,9 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert@2.0.0, assert@^2.0.0, "assert@npm:assert@^2.0.0":
+assert@2.0.0, assert@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
   integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
   dependencies:
     es6-object-assign "^1.1.0"
@@ -5671,11 +5671,6 @@ base-x@^3.0.2, base-x@^3.0.6, base-x@^3.0.8:
   integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
   dependencies:
     safe-buffer "^5.0.1"
-
-base64-js@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
-  integrity sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=
 
 base64-js@^1.0.2, base64-js@^1.2.0, base64-js@^1.3.1:
   version "1.5.1"
@@ -6044,13 +6039,6 @@ buffer@^6.0.3, buffer@~6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
-
-"buffer@npm:buffer-browserify@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.npmjs.org/buffer-browserify/-/buffer-browserify-0.2.5.tgz#29c739d6a4e247b539abc0ada073612002163a21"
-  integrity sha1-Kcc51qTiR7U5q8CtoHNhIAIWOiE=
-  dependencies:
-    base64-js "0.0.8"
 
 bufferutil@^4.0.1:
   version "4.0.6"
@@ -16329,14 +16317,6 @@ stream-parser@^0.3.1:
   integrity sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=
   dependencies:
     debug "2"
-
-"stream@npm:stream-browserify@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
-  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
-  dependencies:
-    inherits "~2.0.4"
-    readable-stream "^3.5.0"
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Reverts solana-labs/wallet-adapter#264 which appears to break the example app.