### PR TITLE
Warn on the console when the WalletModalProvider is missing

### DIFF
--- a/packages/ui/ant-design/src/useWalletModal.ts
+++ b/packages/ui/ant-design/src/useWalletModal.ts
@@ -5,7 +5,30 @@ export interface WalletModalContextState {
     setVisible: (open: boolean) => void;
 }
 
-export const WalletModalContext = createContext<WalletModalContextState>({} as WalletModalContextState);
+const DEFAULT_CONTEXT = {
+    setVisible(_open: boolean) {
+        console.warn(
+            'You have tried to call `setVisible` on a `WalletModalContext` ' +
+                'without providing one. Make sure to render a ' +
+                '`<WalletModalProvider>` as an ancestor of the component ' +
+                'that uses `WalletModalContext`.'
+        );
+    },
+    visible: false,
+};
+Object.defineProperty(DEFAULT_CONTEXT, 'visible', {
+    get() {
+        console.warn(
+            'You have tried to read `visible` on a `WalletModalContext` ' +
+                'without providing one. Make sure to render a ' +
+                '`<WalletModalProvider>` as an ancestor of the component ' +
+                'that uses `WalletModalContext`.'
+        );
+        return false;
+    },
+});
+
+export const WalletModalContext = createContext<WalletModalContextState>(DEFAULT_CONTEXT as WalletModalContextState);
 
 export function useWalletModal(): WalletModalContextState {
     return useContext(WalletModalContext);

--- a/packages/ui/react-ui/src/useWalletModal.tsx
+++ b/packages/ui/react-ui/src/useWalletModal.tsx
@@ -5,7 +5,30 @@ export interface WalletModalContextState {
     setVisible: (open: boolean) => void;
 }
 
-export const WalletModalContext = createContext<WalletModalContextState>({} as WalletModalContextState);
+const DEFAULT_CONTEXT = {
+    setVisible(_open: boolean) {
+        console.warn(
+            'You have tried to call `setVisible` on a `WalletModalContext` ' +
+                'without providing one. Make sure to render a ' +
+                '`<WalletModalProvider>` as an ancestor of the component ' +
+                'that uses `WalletModalContext`.'
+        );
+    },
+    visible: false,
+};
+Object.defineProperty(DEFAULT_CONTEXT, 'visible', {
+    get() {
+        console.warn(
+            'You have tried to read `visible` on a `WalletModalContext` ' +
+                'without providing one. Make sure to render a ' +
+                '`<WalletModalProvider>` as an ancestor of the component ' +
+                'that uses `WalletModalContext`.'
+        );
+        return false;
+    },
+});
+
+export const WalletModalContext = createContext<WalletModalContextState>(DEFAULT_CONTEXT as WalletModalContextState);
 
 export function useWalletModal(): WalletModalContextState {
     return useContext(WalletModalContext);


### PR DESCRIPTION
@21e8 got into a bit of trouble because their app was missing a `WalletModalProvider`.

In this PR, we:

* Make it so that a missing wallet modal provider isn't a runtime error
* A helpful warning appears on the console asking you to add a `<WalletModalProvider>` as an ancestor.

Fixes #286.

Test plan:

1. Remove the `<WalletModalProvider>` from the Next.js example
2. `yarn dev`
3. Click the button

Observe warning on console.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/13243/150913685-1e0d9eaf-af54-4a5f-a265-897ead71bf2d.png">
