### PR TITLE
Alias `stream-browserify` to both `stream` and `stream-browserify`

### DIFF
--- a/packages/wallets/torus/package.json
+++ b/packages/wallets/torus/package.json
@@ -31,7 +31,8 @@
         "@solana/web3.js": "^1.20.0",
         "@toruslabs/solana-embed": "^0.1.0",
         "assert": "npm:assert@^2.0.0",
-        "stream": "npm:stream-browserify@^3.0.0"
+        "stream": "npm:stream-browserify@^3.0.0",
+        "stream-browserify": "^3.0.0"
     },
     "devDependencies": {
         "@types/keccak": "^3.0.1",


### PR DESCRIPTION
So here's a fun one. In #276 we aliased `stream-browserify` to `stream` in the Torus wallet adapter package. We did this because some dependency of Torus presumed that it was running in an environment with Node browser polyfills (eg. that `stream` was available for import).

Fast forward to https://github.com/solana-labs/solana-pay/issues/44. Now you have a situation where the _Torus_ wallet adapter is happy, but some _other_ dependency of `@solana/pay-point-of-sale` now tries to import `stream-browserify`.

1. Recall that `wallet-adapter-torus` aliases `npm:stream-browserify@^3.0.0` to `stream`
2. `@parcel` – a dependency of `@solana/pay-point-of-sale` – depends on `stream-browserify` through `node-libs-browser`
3. Yarn goes ‘oh look; `stream-browserify` is already installed by `wallet-adapter-torus`. Nothing to do here!’
4. When `node-libs-browser` goes to import `stream-browserify` it can't find it. The only path on disk now is `node_modules/stream` because of the alias definition.

The solution in this PR is to just import `stream-browserify` under _both_ names: `stream/` and `stream-browserify/`.

## Test plan

1. In this repo: `(cd packages/wallets/torus && yarn link)`
2. In the Solana Pay repro: `(cd point-of-sale && rm yarn.lock && yarn link @solana/wallet-adapter-torus && yarn && yarn start)`

Project builds. Fixes https://github.com/solana-labs/solana-pay/issues/44