### PR TITLE
Overrides

### DIFF
--- a/packages/starter/example/package.json
+++ b/packages/starter/example/package.json
@@ -35,7 +35,7 @@
         "@solana/wallet-adapter-material-ui": "^0.16.4",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-react-ui": "^0.9.5",
-        "@solana/wallet-adapter-wallets": "^0.15.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
         "@solana/web3.js": "^1.20.0",
         "antd": "~4.16.13",
         "bs58": "^4.0.1",

--- a/packages/starter/example/package.json
+++ b/packages/starter/example/package.json
@@ -35,7 +35,7 @@
         "@solana/wallet-adapter-material-ui": "^0.16.4",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-react-ui": "^0.9.5",
-        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2",
         "@solana/web3.js": "^1.20.0",
         "antd": "~4.16.13",
         "bs58": "^4.0.1",

--- a/packages/starter/material-ui-starter/package.json
+++ b/packages/starter/material-ui-starter/package.json
@@ -36,7 +36,7 @@
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-material-ui": "^0.16.4",
-        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2",
         "@solana/web3.js": "^1.31.0",
         "notistack": "^2.0.0",
         "react": "^17.0.0",

--- a/packages/starter/material-ui-starter/package.json
+++ b/packages/starter/material-ui-starter/package.json
@@ -36,7 +36,7 @@
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-material-ui": "^0.16.4",
-        "@solana/wallet-adapter-wallets": "^0.15.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
         "@solana/web3.js": "^1.31.0",
         "notistack": "^2.0.0",
         "react": "^17.0.0",

--- a/packages/starter/nextjs-starter/package.json
+++ b/packages/starter/nextjs-starter/package.json
@@ -29,7 +29,7 @@
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-react-ui": "^0.9.5",
-        "@solana/wallet-adapter-wallets": "^0.15.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
         "next": "12.0.7",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/packages/starter/nextjs-starter/package.json
+++ b/packages/starter/nextjs-starter/package.json
@@ -29,7 +29,7 @@
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-react-ui": "^0.9.5",
-        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2",
         "next": "12.0.7",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/packages/starter/react-ui-starter/package.json
+++ b/packages/starter/react-ui-starter/package.json
@@ -32,7 +32,7 @@
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-react-ui": "^0.9.5",
-        "@solana/wallet-adapter-wallets": "^0.15.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
         "@solana/web3.js": "^1.31.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0"

--- a/packages/starter/react-ui-starter/package.json
+++ b/packages/starter/react-ui-starter/package.json
@@ -32,7 +32,7 @@
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/wallet-adapter-react": "^0.15.3",
         "@solana/wallet-adapter-react-ui": "^0.9.5",
-        "@solana/wallet-adapter-wallets": "^0.15.2-alpha.0",
+        "@solana/wallet-adapter-wallets": "^0.15.2",
         "@solana/web3.js": "^1.31.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0"

--- a/packages/wallets/ledger/package.json
+++ b/packages/wallets/ledger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-ledger",
-    "version": "0.9.6-alpha.0",
+    "version": "0.9.6",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/wallets/ledger/package.json
+++ b/packages/wallets/ledger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-ledger",
-    "version": "0.9.5",
+    "version": "0.9.6-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -30,10 +30,12 @@
         "@ledgerhq/hw-transport": "^6.11.2",
         "@ledgerhq/hw-transport-webhid": "^6.11.2",
         "@solana/wallet-adapter-base": "^0.9.3",
-        "@solana/web3.js": "^1.20.0",
-        "buffer": "npm:buffer@^6.0.3"
+        "@solana/web3.js": "^1.20.0"
     },
     "devDependencies": {
         "@types/w3c-web-hid": "^1.0.2"
+    },
+    "overrides": {
+        "buffer": "npm:buffer@^6.0.3"
     }
 }

--- a/packages/wallets/torus/package.json
+++ b/packages/wallets/torus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-torus",
-    "version": "0.11.7",
+    "version": "0.11.8-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -29,13 +29,14 @@
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.3",
         "@solana/web3.js": "^1.20.0",
-        "@toruslabs/solana-embed": "^0.1.0",
-        "assert": "npm:assert@^2.0.0",
-        "stream": "npm:stream-browserify@^3.0.0",
-        "stream-browserify": "^3.0.0"
+        "@toruslabs/solana-embed": "^0.1.0"
     },
     "devDependencies": {
         "@types/keccak": "^3.0.1",
         "@types/readable-stream": "^2.3.11"
+    },
+    "overrides": {
+        "assert": "npm:assert@^2.0.0",
+        "stream": "npm:stream-browserify@^3.0.0"
     }
 }

--- a/packages/wallets/torus/package.json
+++ b/packages/wallets/torus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-torus",
-    "version": "0.11.8-alpha.0",
+    "version": "0.11.8",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/wallets/wallets/package.json
+++ b/packages/wallets/wallets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-wallets",
-    "version": "0.15.2-alpha.0",
+    "version": "0.15.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -34,7 +34,7 @@
         "@solana/wallet-adapter-clover": "^0.4.2",
         "@solana/wallet-adapter-coin98": "^0.5.2",
         "@solana/wallet-adapter-coinhub": "^0.3.2",
-        "@solana/wallet-adapter-ledger": "^0.9.6-alpha.0",
+        "@solana/wallet-adapter-ledger": "^0.9.6",
         "@solana/wallet-adapter-mathwallet": "^0.9.2",
         "@solana/wallet-adapter-phantom": "^0.9.2",
         "@solana/wallet-adapter-safepal": "^0.5.2",
@@ -43,6 +43,6 @@
         "@solana/wallet-adapter-sollet": "^0.11.0",
         "@solana/wallet-adapter-solong": "^0.9.2",
         "@solana/wallet-adapter-tokenpocket": "^0.4.2",
-        "@solana/wallet-adapter-torus": "^0.11.8-alpha.0"
+        "@solana/wallet-adapter-torus": "^0.11.8"
     }
 }

--- a/packages/wallets/wallets/package.json
+++ b/packages/wallets/wallets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-wallets",
-    "version": "0.15.1",
+    "version": "0.15.2-alpha.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -34,7 +34,7 @@
         "@solana/wallet-adapter-clover": "^0.4.2",
         "@solana/wallet-adapter-coin98": "^0.5.2",
         "@solana/wallet-adapter-coinhub": "^0.3.2",
-        "@solana/wallet-adapter-ledger": "^0.9.4",
+        "@solana/wallet-adapter-ledger": "^0.9.6-alpha.0",
         "@solana/wallet-adapter-mathwallet": "^0.9.2",
         "@solana/wallet-adapter-phantom": "^0.9.2",
         "@solana/wallet-adapter-safepal": "^0.5.2",
@@ -43,6 +43,6 @@
         "@solana/wallet-adapter-sollet": "^0.11.0",
         "@solana/wallet-adapter-solong": "^0.9.2",
         "@solana/wallet-adapter-tokenpocket": "^0.4.2",
-        "@solana/wallet-adapter-torus": "^0.11.6"
+        "@solana/wallet-adapter-torus": "^0.11.8-alpha.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4613,7 +4613,7 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert@2.0.0, assert@^2.0.0, "assert@npm:assert@^2.0.0":
+assert@2.0.0, assert@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
   integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
@@ -5157,7 +5157,7 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-buffer@^6.0.3, "buffer@npm:buffer@^6.0.3", buffer@~6.0.3:
+buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -12518,9 +12518,9 @@ side-channel@^1.0.4:
     object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
-  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 simple-concat@^1.0.0:
   version "1.0.1"
@@ -12756,7 +12756,7 @@ stacktrace-parser@0.1.10:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stream-browserify@3.0.0, stream-browserify@^3.0.0, "stream@npm:stream-browserify@^3.0.0":
+stream-browserify@3.0.0, stream-browserify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
   integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==


### PR DESCRIPTION
This is a followup to #295 and #276 to fix https://github.com/solana-labs/solana-pay/issues/44 and deployment build issues from https://github.com/solana-labs/solana-pay/issues/46.

This PR uses [npm overrides](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) to accomplish the desired package aliasing without changing the names of the aliases.