### PR TITLE
Add listener to DOMContentLoaded when document readyState is loading

### DIFF
--- a/packages/core/base/src/adapter.ts
+++ b/packages/core/base/src/adapter.ts
@@ -106,14 +106,24 @@ export function scopePollingDetectionStrategy(detect: () => boolean): void {
         }, 1000);
     };
 
+    function windowDOMContentLoadedListener() {
+        window.removeEventListener('DOMContentLoaded', windowDOMContentLoadedListener);
+        poll();
+    }
+
+    if (document.readyState === 'loading') {
+        window.addEventListener('DOMContentLoaded', windowDOMContentLoadedListener);
+        return;
+    }
+
     if (document.readyState === 'complete') {
         poll();
         return;
     }
 
-    function listener() {
-        window.removeEventListener('load', listener);
+    function windowLoadListener() {
+        window.removeEventListener('load', windowLoadListener);
         poll();
     }
-    window.addEventListener('load', listener);
+    window.addEventListener('load', windowLoadListener);
 }


### PR DESCRIPTION
## Problem
The document load event waits for the browser to load all resources before executing [(reference)](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event). The Magic Eden web app is very resource heavily with all our images, videos, and gifs which caused the wallet connection to be delayed. The quick patch we used was to listen to the [DOMContentLoaded event](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event) so wallets can be connected before all the resources loaded.

## Solution 
@ArpitAgrawal321 suggested in https://github.com/solana-labs/wallet-adapter/issues/317 to fully use DOMContentLoaded for this case. @steveluscher [suggested](https://github.com/solana-labs/wallet-adapter/issues/317#issuecomment-1050538881) to also handle the in-between states of the document loading and finished loading.

This PR adds a `DOMContentLoaded` listener when the document state is loading while still watching the window `load` event in the case that the document is in the `complete` state