### PR TITLE
Adding emotion libary to example starter dependencies so the project can run 

### DIFF
--- a/packages/starter/example/package.json
+++ b/packages/starter/example/package.json
@@ -28,8 +28,10 @@
     },
     "dependencies": {
         "@ant-design/icons": "^4.0.0",
+        "@emotion/react": "^11.8.2",
+        "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.5.0",
-        "@mui/material": "^5.5.0",
+        "@mui/material": "^5.5.2",
         "@solana/wallet-adapter-ant-design": "^0.11.3",
         "@solana/wallet-adapter-base": "^0.9.4",
         "@solana/wallet-adapter-material-ui": "^0.16.4",


### PR DESCRIPTION
before installing these libraries `npm run dev` wouldn't work. I kept getting the following error.
```
ready - started server on 0.0.0.0:3000, url: http://localhost:3000
error - ./node_modules/@mui/styled-engine/index.js:6:0
Module not found: Can't resolve '@emotion/styled'

Import trace for requested module:
./node_modules/@mui/system/esm/index.js
./node_modules/@mui/material/styles/index.js
./node_modules/@mui/material/index.js
./components/ContextProvider.tsx
./pages/_app.tsx

https://nextjs.org/docs/messages/module-not-found
wait  - compiling /_error (client and server)...
```

[This StackOverflow answer has more information about this problem and solution](https://stackoverflow.com/questions/69351693/mui-v5-cant-resolve-emotion-react-in-node-modules-mui-styled-engine)

# Steps to reproduce the Bug
[Clone, install and run (dev) the started project](https://github.com/solana-labs/wallet-adapter/tree/master/packages/starter/example). When you navigate to loaclhos:3000 you will see the above error.

# Steps to test the solution
Clone, install and run (dev) this pull request. and see that the project works and runs all fine.