### PR TITLE
Better TypeScript Hints for WalletName

### DIFF
--- a/packages/core/base/src/adapter.ts
+++ b/packages/core/base/src/adapter.ts
@@ -15,12 +15,12 @@ export interface SendTransactionOptions extends SendOptions {
     signers?: Signer[];
 }
 
-// WalletName is a nominal type that wallet adapters should use, e.g. `'MyCryptoWallet' as WalletName`
+// WalletName is a nominal type that wallet adapters should use, e.g. `'MyCryptoWallet' as WalletName<'MyCryptoWallet'>`
 // https://medium.com/@KevinBGreene/surviving-the-typescript-ecosystem-branding-and-type-tagging-6cf6e516523d
-export type WalletName = string & { __brand__: 'WalletName' };
+export type WalletName<T extends string = string> = T & { __brand__: 'WalletName' };
 
-export interface WalletAdapterProps {
-    name: WalletName;
+export interface WalletAdapterProps<Name extends string = string> {
+    name: WalletName<Name>;
     url: string;
     icon: string;
     readyState: WalletReadyState;
@@ -37,7 +37,7 @@ export interface WalletAdapterProps {
     ): Promise<TransactionSignature>;
 }
 
-export type WalletAdapter = WalletAdapterProps & EventEmitter<WalletAdapterEvents>;
+export type WalletAdapter<Name extends string = string> = WalletAdapterProps<Name> & EventEmitter<WalletAdapterEvents>;
 
 /**
  * A wallet's readiness describes a series of states that the wallet can be in,

--- a/packages/core/react/src/__tests__/WalletProvider-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProvider-test.tsx
@@ -89,19 +89,19 @@ describe('WalletProvider', () => {
         sendTransaction = jest.fn();
     }
     class FooWalletAdapter extends MockWalletAdapter {
-        name = 'FooWallet' as WalletName;
+        name = 'FooWallet' as WalletName<'FooWallet'>;
         url = 'https://foowallet.com';
         icon = 'foo.png';
         publicKey = new PublicKey('Foo11111111111111111111111111111111111111111');
     }
     class BarWalletAdapter extends MockWalletAdapter {
-        name = 'BarWallet' as WalletName;
+        name = 'BarWallet' as WalletName<'BarWallet'>;
         url = 'https://barwallet.com';
         icon = 'bar.png';
         publicKey = new PublicKey('Bar11111111111111111111111111111111111111111');
     }
     class BazWalletAdapter extends MockWalletAdapter {
-        name = 'BazWallet' as WalletName;
+        name = 'BazWallet' as WalletName<'BazWallet'>;
         url = 'https://bazwallet.com';
         icon = 'baz.png';
         publicKey = new PublicKey('Baz11111111111111111111111111111111111111111');
@@ -130,7 +130,7 @@ describe('WalletProvider', () => {
             fooWalletAdapter.readyStateValue = WalletReadyState.NotDetected;
             renderTest({});
             await act(async () => {
-                ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                 await Promise.resolve(); // Flush all promises in effects after calling `select()`.
             });
             expect(ref.current?.getWalletContextState().wallet?.readyState).toBe(WalletReadyState.NotDetected);
@@ -255,7 +255,7 @@ describe('WalletProvider', () => {
             handleError = jest.fn();
             renderTest({ onError: handleError });
             await act(async () => {
-                ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                 await Promise.resolve(); // Flush all promises in effects after calling `select()`.
             });
         });
@@ -281,7 +281,7 @@ describe('WalletProvider', () => {
                 fooWalletAdapter.readyStateValue = WalletReadyState.NotDetected;
                 renderTest({});
                 act(() => {
-                    ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                    ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                 });
                 expect(ref.current?.getWalletContextState().wallet?.readyState).toBe(WalletReadyState.NotDetected);
                 act(() => {
@@ -310,7 +310,7 @@ describe('WalletProvider', () => {
             beforeEach(async () => {
                 renderTest({});
                 await act(async () => {
-                    ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                    ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                     await Promise.resolve(); // Flush all promises in effects after calling `select()`.
                 });
                 fooWalletAdapter.connectionPromise = new Promise<void>((resolve) => {
@@ -351,7 +351,7 @@ describe('WalletProvider', () => {
                 window.open = jest.fn();
                 renderTest({});
                 await act(async () => {
-                    ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                    ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                     await Promise.resolve(); // Flush all promises in effects after calling `select()`.
                 });
                 act(() => {
@@ -395,7 +395,7 @@ describe('WalletProvider', () => {
                 beforeEach(async () => {
                     renderTest({});
                     await act(async () => {
-                        ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                        ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                         await Promise.resolve(); // Flush all promises in effects after calling `select()`.
                     });
                 });
@@ -417,14 +417,14 @@ describe('WalletProvider', () => {
                 });
                 renderTest({});
                 await act(async () => {
-                    ref.current?.getWalletContextState().select('FooWallet' as WalletName);
+                    ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
                     await Promise.resolve(); // Flush all promises in effects after calling `select()`.
                 });
             });
             describe('and you select a different wallet', () => {
                 beforeEach(async () => {
                     await act(async () => {
-                        ref.current?.getWalletContextState().select('BarWallet' as WalletName);
+                        ref.current?.getWalletContextState().select('BarWallet' as WalletName<'BarWallet'>);
                         await Promise.resolve(); // Flush all promises in effects after calling `select()`.
                     });
                 });
@@ -442,7 +442,7 @@ describe('WalletProvider', () => {
                 describe('then change your mind before the first one has disconnected', () => {
                     beforeEach(async () => {
                         await act(async () => {
-                            ref.current?.getWalletContextState().select('BazWallet' as WalletName);
+                            ref.current?.getWalletContextState().select('BazWallet' as WalletName<'BazWallet'>);
                             await Promise.resolve(); // Flush all promises in effects after calling `select()`.
                         });
                         act(() => {

--- a/packages/wallets/bitkeep/src/adapter.ts
+++ b/packages/wallets/bitkeep/src/adapter.ts
@@ -31,7 +31,7 @@ declare const window: BitKeepWindow;
 
 export interface BitKeepWalletAdapterConfig {}
 
-export const BitKeepWalletName = 'BitKeep' as WalletName;
+export const BitKeepWalletName = 'BitKeep' as WalletName<'BitKeep'>;
 
 export class BitKeepWalletAdapter extends BaseSignerWalletAdapter {
     name = BitKeepWalletName;

--- a/packages/wallets/bitpie/src/adapter.ts
+++ b/packages/wallets/bitpie/src/adapter.ts
@@ -25,7 +25,7 @@ declare const window: BitpieWalletWindow;
 
 export interface BitpieWalletAdapterConfig {}
 
-export const BitpieWalletName = 'Bitpie' as WalletName;
+export const BitpieWalletName = 'Bitpie' as WalletName<'Bitpie'>;
 
 export class BitpieWalletAdapter extends BaseSignerWalletAdapter {
     name = BitpieWalletName;

--- a/packages/wallets/blocto/src/adapter.ts
+++ b/packages/wallets/blocto/src/adapter.ts
@@ -21,7 +21,7 @@ export interface BloctoWalletAdapterConfig {
     network?: WalletAdapterNetwork;
 }
 
-export const BloctoWalletName = 'Blocto' as WalletName;
+export const BloctoWalletName = 'Blocto' as WalletName<'Blocto'>;
 
 export class BloctoWalletAdapter extends BaseWalletAdapter {
     name = BloctoWalletName;

--- a/packages/wallets/clover/src/adapter.ts
+++ b/packages/wallets/clover/src/adapter.ts
@@ -27,7 +27,7 @@ declare const window: CloverWalletWindow;
 
 export interface CloverWalletAdapterConfig {}
 
-export const CloverWalletName = 'Clover' as WalletName;
+export const CloverWalletName = 'Clover' as WalletName<'Clover'>;
 
 export class CloverWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = CloverWalletName;

--- a/packages/wallets/coin98/src/adapter.ts
+++ b/packages/wallets/coin98/src/adapter.ts
@@ -35,7 +35,7 @@ declare const window: Coin98Window;
 
 export interface Coin98WalletAdapterConfig {}
 
-export const Coin98WalletName = 'Coin98' as WalletName;
+export const Coin98WalletName = 'Coin98' as WalletName<'Coin98'>;
 
 export class Coin98WalletAdapter extends BaseMessageSignerWalletAdapter {
     name = Coin98WalletName;

--- a/packages/wallets/coinhub/src/adapter.ts
+++ b/packages/wallets/coinhub/src/adapter.ts
@@ -26,7 +26,7 @@ declare const window: CoinhubWalletWindow;
 
 export interface CoinhubWalletAdapterConfig {}
 
-export const CoinhubWalletName = 'Coinhub' as WalletName;
+export const CoinhubWalletName = 'Coinhub' as WalletName<'Coinhub'>;
 
 export class CoinhubWalletAdapter extends BaseSignerWalletAdapter {
     name = CoinhubWalletName;

--- a/packages/wallets/glow/src/adapter.ts
+++ b/packages/wallets/glow/src/adapter.ts
@@ -45,7 +45,7 @@ declare const window: GlowWindow;
 
 export interface GlowWalletAdapterConfig {}
 
-export const GlowWalletName = 'Glow' as WalletName;
+export const GlowWalletName = 'Glow' as WalletName<'Glow'>;
 
 export class GlowWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = GlowWalletName;

--- a/packages/wallets/huobi/src/adapter.ts
+++ b/packages/wallets/huobi/src/adapter.ts
@@ -38,7 +38,7 @@ declare const window: HuobiWalletWindow;
 
 export interface HuobiWalletAdapterConfig {}
 
-export const HuobiWalletName = 'HuobiWallet' as WalletName;
+export const HuobiWalletName = 'HuobiWallet' as WalletName<'HuobiWallet'>;
 
 export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = HuobiWalletName;

--- a/packages/wallets/ledger/src/adapter.ts
+++ b/packages/wallets/ledger/src/adapter.ts
@@ -21,7 +21,7 @@ export interface LedgerWalletAdapterConfig {
     derivationPath?: Buffer;
 }
 
-export const LedgerWalletName = 'Ledger' as WalletName;
+export const LedgerWalletName = 'Ledger' as WalletName<'Ledger'>;
 
 export class LedgerWalletAdapter extends BaseSignerWalletAdapter {
     name = LedgerWalletName;

--- a/packages/wallets/mathwallet/src/adapter.ts
+++ b/packages/wallets/mathwallet/src/adapter.ts
@@ -27,7 +27,7 @@ declare const window: MathWalletWindow;
 
 export interface MathWalletAdapterConfig {}
 
-export const MathWalletName = 'MathWallet' as WalletName;
+export const MathWalletName = 'MathWallet' as WalletName<'MathWallet'>;
 
 export class MathWalletAdapter extends BaseSignerWalletAdapter {
     name = MathWalletName;

--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -47,7 +47,7 @@ declare const window: PhantomWindow;
 
 export interface PhantomWalletAdapterConfig {}
 
-export const PhantomWalletName = 'Phantom' as WalletName;
+export const PhantomWalletName = 'Phantom' as WalletName<'Phantom'>;
 
 export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = PhantomWalletName;

--- a/packages/wallets/safepal/src/adapter.ts
+++ b/packages/wallets/safepal/src/adapter.ts
@@ -26,7 +26,7 @@ declare const window: SafePalWalletWindow;
 
 export interface SafePalWalletAdapterConfig {}
 
-export const SafePalWalletName = 'SafePal' as WalletName;
+export const SafePalWalletName = 'SafePal' as WalletName<'SafePal'>;
 
 export class SafePalWalletAdapter extends BaseSignerWalletAdapter {
     name = SafePalWalletName;

--- a/packages/wallets/slope/src/adapter.ts
+++ b/packages/wallets/slope/src/adapter.ts
@@ -51,7 +51,7 @@ declare const window: SlopeWindow;
 
 export interface SlopeWalletAdapterConfig {}
 
-export const SlopeWalletName = 'Slope' as WalletName;
+export const SlopeWalletName = 'Slope' as WalletName<'Slope'>;
 
 export class SlopeWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = SlopeWalletName;

--- a/packages/wallets/solflare/src/adapter.ts
+++ b/packages/wallets/solflare/src/adapter.ts
@@ -30,7 +30,7 @@ export interface SolflareWalletAdapterConfig {
     network?: WalletAdapterNetwork;
 }
 
-export const SolflareWalletName = 'Solflare' as WalletName;
+export const SolflareWalletName = 'Solflare' as WalletName<'Solflare'>;
 
 export class SolflareWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = SolflareWalletName;

--- a/packages/wallets/sollet/src/adapter.ts
+++ b/packages/wallets/sollet/src/adapter.ts
@@ -1,7 +1,7 @@
 import { WalletName } from '@solana/wallet-adapter-base';
 import { BaseSolletWalletAdapter, SolletWalletAdapterConfig } from './base';
 
-export const SolletWalletName = 'Sollet' as WalletName;
+export const SolletWalletName = 'Sollet' as WalletName<'Sollet'>;
 
 export class SolletWalletAdapter extends BaseSolletWalletAdapter {
     name = SolletWalletName;
@@ -14,7 +14,7 @@ export class SolletWalletAdapter extends BaseSolletWalletAdapter {
     }
 }
 
-export const SolletExtensionWalletName = 'Sollet (Extension)' as WalletName;
+export const SolletExtensionWalletName = 'Sollet (Extension)' as WalletName<'Sollet (Extension)'>;
 
 export class SolletExtensionWalletAdapter extends BaseSolletWalletAdapter {
     name = SolletExtensionWalletName;

--- a/packages/wallets/solong/src/adapter.ts
+++ b/packages/wallets/solong/src/adapter.ts
@@ -25,7 +25,7 @@ declare const window: SolongWindow;
 
 export interface SolongWalletAdapterConfig {}
 
-export const SolongWalletName = 'Solong' as WalletName;
+export const SolongWalletName = 'Solong' as WalletName<'Solong'>;
 
 export class SolongWalletAdapter extends BaseSignerWalletAdapter {
     name = SolongWalletName;

--- a/packages/wallets/tokenpocket/src/adapter.ts
+++ b/packages/wallets/tokenpocket/src/adapter.ts
@@ -38,7 +38,7 @@ declare const window: TokenPocketWindow;
 
 export interface TokenPocketWalletAdapterConfig {}
 
-export const TokenPocketWalletName = 'TokenPocket' as WalletName;
+export const TokenPocketWalletName = 'TokenPocket' as WalletName<'TokenPocket'>;
 
 export class TokenPocketWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = TokenPocketWalletName;

--- a/packages/wallets/torus/src/adapter.ts
+++ b/packages/wallets/torus/src/adapter.ts
@@ -25,7 +25,7 @@ interface TorusWindow extends Window {
 
 declare const window: TorusWindow;
 
-export const TorusWalletName = 'Torus' as WalletName;
+export const TorusWalletName = 'Torus' as WalletName<'Torus'>;
 
 export class TorusWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = TorusWalletName;


### PR DESCRIPTION
This PR adds an optional type (no breaking changes) on the `WalletName` to support better typescript hints. 

Previously, in application code, the user would see the following as a hint:
<img width="380" alt="Screen Shot 2022-03-30 at 2 32 57 PM" src="https://user-images.githubusercontent.com/6139501/160934617-d54653a6-b69e-4250-8434-a9afce22bbc4.png">

With this PR, they will see:
<img width="464" alt="Screen Shot 2022-03-30 at 2 34 06 PM" src="https://user-images.githubusercontent.com/6139501/160934770-5993df2f-f3ae-4f12-b1e8-9a6d6d49da80.png">