### PR TITLE
bump react 18

### DIFF
--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -37,10 +37,10 @@
     "devDependencies": {
         "@solana/web3.js": "^1.36.0",
         "@types/jest": "^27.0.0",
-        "@types/react": "^17.0.40",
+        "@types/react": "^18.0.0",
         "jest": "^27.0.0",
         "jest-localstorage-mock": "^2.4.18",
-        "react": "^17.0.0",
+        "react": "^18.0.0",
         "ts-jest": "^27.0.0"
     }
 }


### PR DESCRIPTION
seeing dep mismatch when installing in create react app 
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: my-app@0.1.0
npm ERR! Found: react@18.1.0
npm ERR! node_modules/react
npm ERR!   react@"^18.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0" from @solana/wallet-adapter-react@0.15.4
npm ERR! node_modules/@solana/wallet-adapter-react
npm ERR!   @solana/wallet-adapter-react@"*" from the root project
```