### PR TITLE
Retry Glow wallet detection

### DIFF
--- a/packages/wallets/glow/src/adapter.ts
+++ b/packages/wallets/glow/src/adapter.ts
@@ -139,9 +139,9 @@ export class GlowWalletAdapter extends BaseMessageSignerWalletAdapter {
     async connect(): Promise<void> {
         try {
             if (this.connected || this.connecting) return;
+            this._connecting = true;
             await this.awaitReadyState();
 
-            this._connecting = true;
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window!.glowSolana!;


### PR DESCRIPTION
We've noticed an elevated number of errors on some pages which seem to be trying to connect to Glow wallet before it gets to register itself (in Safari extension). While this technically shouldn't happen since Safari extension content scripts are expected to run on `document_start`, [so before any page scripts](https://developer.chrome.com/docs/extensions/mv2/content_scripts/#run_time), some Safari settings (Preload Top Hit) may break this behavior as noted in [this article](https://lapcatsoftware.com/articles/2021-6-11.html).

This pull request aims to mitigate this behavior by waiting for wallet to register itself in `connect()`. If after 3 seconds the wallet still isn't ready we throw `WalletNotReadyError` as we do right now. Similar solution has been implemented in https://github.com/saber-hq/saber-common/pull/500.