### PR TITLE
fix: handle accountChanged event for phantom

### DIFF
--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -21,6 +21,7 @@ import { Connection, PublicKey, SendOptions, Transaction, TransactionSignature }
 interface PhantomWalletEvents {
     connect(...args: unknown[]): unknown;
     disconnect(...args: unknown[]): unknown;
+    accountChanged(publicKey: PublicKey): void;
 }
 
 interface PhantomWallet extends EventEmitter<PhantomWalletEvents> {

--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -149,7 +149,7 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
             }
 
             wallet.on('disconnect', this._disconnected);
-            wallet.on('accountChanged', this._handleAccountChanged);
+            wallet.on('accountChanged', this._accountChanged);
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -167,7 +167,7 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
         const wallet = this._wallet;
         if (wallet) {
             wallet.off('disconnect', this._disconnected);
-            wallet.off('accountChanged', this._handleAccountChanged);
+            wallet.off('accountChanged', this._accountChanged);
 
             this._wallet = null;
             this._publicKey = null;
@@ -256,14 +256,11 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _handleAccountChanged = (publicKey: PublicKey) => {
-        this.emit('connect', publicKey);
-    };
-
     private _disconnected = () => {
         const wallet = this._wallet;
         if (wallet) {
             wallet.off('disconnect', this._disconnected);
+            wallet.off('accountChanged', this._accountChanged);
 
             this._wallet = null;
             this._publicKey = null;
@@ -271,5 +268,9 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
+    };
+
+    private _accountChanged = (publicKey: PublicKey) => {
+        this.emit('connect', publicKey);
     };
 }

--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -148,6 +148,7 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
             }
 
             wallet.on('disconnect', this._disconnected);
+            wallet.on('accountChanged', this._handleAccountChanged);
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -165,6 +166,7 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
         const wallet = this._wallet;
         if (wallet) {
             wallet.off('disconnect', this._disconnected);
+            wallet.off('accountChanged', this._handleAccountChanged);
 
             this._wallet = null;
             this._publicKey = null;
@@ -252,6 +254,10 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
             throw error;
         }
     }
+
+    private _handleAccountChanged = (publicKey: PublicKey) => {
+        this.emit('connect', publicKey);
+    };
 
     private _disconnected = () => {
         const wallet = this._wallet;


### PR DESCRIPTION
There's a scenario where in phantom, when you change wallet for a trusted domain, it will call `accountChanged` instead of `disconnect` event, this has caused quite a number of transaction failed from our analytic at Jupiter.