### PR TITLE
Add signMessage function to Bitkeep adapter

### DIFF
--- a/packages/wallets/bitkeep/src/adapter.ts
+++ b/packages/wallets/bitkeep/src/adapter.ts
@@ -19,6 +19,7 @@ interface BitKeepWallet {
     getAccount(): Promise<string>;
     signTransaction(transaction: Transaction): Promise<Transaction>;
     signAllTransactions(transactions: Transaction[]): Promise<Transaction[]>;
+    signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>;
 }
 
 interface BitKeepWindow extends Window {
@@ -152,6 +153,23 @@ export class BitKeepWalletAdapter extends BaseSignerWalletAdapter {
 
             try {
                 return (await wallet.signAllTransactions(transactions)) || transactions;
+            } catch (error: any) {
+                throw new WalletSignTransactionError(error?.message, error);
+            }
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+
+    async signMessage(message: Uint8Array): Promise<Uint8Array> {
+        try {
+            const wallet = this._wallet;
+            if (!wallet) throw new WalletNotConnectedError();
+
+            try {
+                const { signature } = await wallet.signMessage(message);
+                return signature;
             } catch (error: any) {
                 throw new WalletSignTransactionError(error?.message, error);
             }


### PR DESCRIPTION
Add signMessage function to the Bitkeep adapter. 

Code is copied from Phantom adapter, so should be straight forward. 