### PR TITLE
Simplify Exodus wallet adapter

### DIFF
--- a/packages/wallets/exodus/src/adapter.ts
+++ b/packages/wallets/exodus/src/adapter.ts
@@ -111,19 +111,7 @@ export class ExodusWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             if (!wallet.isConnected) {
                 try {
-                    await new Promise<void>((resolve, reject) => {
-                        const connect = () => {
-                            wallet.off('connect', connect);
-                            resolve();
-                        };
-
-                        wallet.on('connect', connect);
-
-                        wallet.connect().catch((reason: any) => {
-                            wallet.off('connect', connect);
-                            reject(reason);
-                        });
-                    });
+                    await wallet.connect();
                 } catch (error: any) {
                     throw new WalletConnectionError(error?.message, error);
                 }


### PR DESCRIPTION
## Summary

This PR simplifies the `connect` method, as Exodus rejects if the approve connection popup is closed by the user.

Closes: #449 (along with changes in https://github.com/solana-labs/wallet-adapter/commit/86bcea430a7f235a3da125eea15bd0110e2695d1, thanks @jordansexton)