### PR TITLE
change CoinbaseWalletName from Coinbase to Coinbase Wallet

### DIFF
--- a/packages/wallets/coinbase/src/adapter.ts
+++ b/packages/wallets/coinbase/src/adapter.ts
@@ -44,7 +44,7 @@ declare const window: CoinbaseWindow;
 
 export interface CoinbaseWalletAdapterConfig {}
 
-export const CoinbaseWalletName = 'Coinbase' as WalletName;
+export const CoinbaseWalletName = 'Coinbase Wallet' as WalletName;
 
 export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = CoinbaseWalletName;


### PR DESCRIPTION
For product/brand clarity, we need to change the wallet name to Coinbase Wallet