### PR TITLE
fix: prevent error on React Native by punting on `localStorage` implementation

### DIFF
--- a/packages/core/react/src/useLocalStorage.native.ts
+++ b/packages/core/react/src/useLocalStorage.native.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import { useLocalStorage as baseUseLocalStorage } from './useLocalStorage';
+
+export const useLocalStorage: typeof baseUseLocalStorage = function useLocalStorage<T>(
+    _key: string,
+    defaultState: T
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+    /**
+     * Until such time as we have a strategy for implementing wallet
+     * memorization on React Native, simply punt and return a no-op.
+     */
+    return useState(defaultState);
+};


### PR DESCRIPTION
Since React Native's storage implementation is _async_, I couldn't think of a good way to shim it in to this _sync_ API we've created. I'll keep thinking about it, but for now this PR exists to shut `useLocalStorage` up when used on React Native.