### PR TITLE
fix: `children` overwriting account address

### DIFF
--- a/packages/ui/react-ui/src/Button.tsx
+++ b/packages/ui/react-ui/src/Button.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, CSSProperties, FC, MouseEvent, PropsWithChildren, ReactElement } from 'react';
 
 export type ButtonProps = PropsWithChildren<{
-    children?: ReactNode;
     buttonText?: string;
     address?: string;
     className?: string;

--- a/packages/ui/react-ui/src/Button.tsx
+++ b/packages/ui/react-ui/src/Button.tsx
@@ -1,6 +1,9 @@
-import React, { CSSProperties, FC, MouseEvent, PropsWithChildren, ReactElement } from 'react';
+import React, { ReactNode, CSSProperties, FC, MouseEvent, PropsWithChildren, ReactElement } from 'react';
 
 export type ButtonProps = PropsWithChildren<{
+    children?: ReactNode;
+    buttonText?: string;
+    address?: string;
     className?: string;
     disabled?: boolean;
     endIcon?: ReactElement;
@@ -20,6 +23,7 @@ export const Button: FC<ButtonProps> = (props) => {
             type="button"
         >
             {props.startIcon && <i className="wallet-adapter-button-start-icon">{props.startIcon}</i>}
+            {props.address !== undefined ? props.address : props.buttonText}
             {props.children}
             {props.endIcon && <i className="wallet-adapter-button-end-icon">{props.endIcon}</i>}
         </button>

--- a/packages/ui/react-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/react-ui/src/WalletMultiButton.tsx
@@ -14,11 +14,15 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
     const ref = useRef<HTMLUListElement>(null);
 
     const base58 = useMemo(() => publicKey?.toBase58(), [publicKey]);
+
     const content = useMemo(() => {
         if (children) return children;
+    }, [children]);
+    
+    const address = useMemo(() => {
         if (!wallet || !base58) return null;
         return base58.slice(0, 4) + '..' + base58.slice(-4);
-    }, [children, wallet, base58]);
+    }, [wallet, base58]);
 
     const copyAddress = useCallback(async () => {
         if (base58) {
@@ -73,7 +77,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
                 startIcon={<WalletIcon wallet={wallet} />}
                 {...props}
             >
-                {content}
+                {address ?? content}
             </Button>
             <ul
                 aria-label="dropdown-list"

--- a/packages/ui/react-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/react-ui/src/WalletMultiButton.tsx
@@ -6,7 +6,7 @@ import { WalletConnectButton } from './WalletConnectButton';
 import { WalletIcon } from './WalletIcon';
 import { WalletModalButton } from './WalletModalButton';
 
-export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
+export const WalletMultiButton: FC<ButtonProps> = ({ children, buttonText, ...props }) => {
     const { publicKey, wallet, disconnect } = useWallet();
     const { setVisible } = useWalletModal();
     const [copied, setCopied] = useState(false);
@@ -75,9 +75,11 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
                 style={{ pointerEvents: active ? 'none' : 'auto', ...props.style }}
                 onClick={openDropdown}
                 startIcon={<WalletIcon wallet={wallet} />}
+                buttonText={buttonText}
+                address={address}
                 {...props}
             >
-                {address ?? content}
+                {content}
             </Button>
             <ul
                 aria-label="dropdown-list"


### PR DESCRIPTION
Fixes #470 

## Update
I offer two potential solutions in this PR:
1. Commit https://github.com/solana-labs/wallet-adapter/pull/471/commits/ecad40d5e55e44f0fdea6cba0420a8a2bac706aa: simple change that diplays `address` if detected, and if not, displays `children` (defined as `content` instead
2. Commits https://github.com/solana-labs/wallet-adapter/pull/471/commits/13c541748d44a102a2ee690440f04405e7a7a4ee through https://github.com/solana-labs/wallet-adapter/pull/471/commits/36ba33d9c4f74e8022b4a90f5ff7c0beea51e1e3: defines two 2 new _optional_ properties on `Button.tsx`: `buttonText` and `account`, which are both used in `WalletMultiButton.tsx`

## Note
Idk how to build this project locally to run a test that this fix is bug free