### PR TITLE
fix: replace getRecentBlockhash with getLatestBlockhash

### DIFF
--- a/packages/core/base/src/adapter.ts
+++ b/packages/core/base/src/adapter.ts
@@ -94,7 +94,7 @@ export abstract class BaseWalletAdapter extends EventEmitter<WalletAdapterEvents
 
         transaction.feePayer = transaction.feePayer || publicKey;
         transaction.recentBlockhash =
-            transaction.recentBlockhash || (await connection.getRecentBlockhash('finalized')).blockhash;
+            transaction.recentBlockhash || (await connection.getLatestBlockhash('confirmed')).blockhash;
 
         return transaction;
     }


### PR DESCRIPTION
In cases where a dapp does not set a `recentBlockhash`, the wallet adapter will currently fallback to polling for one via [getRecentBlockhash](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getRecentBlockhash). This method has been deprecated in favor of [getLatestBlockhash](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getLatestBlockhash).

During times of network congestion, it's important for transactions to include the latest blockhash so that they don't expire early on retries. There is a tradeoff between using various commitment levels. @jstarry has a [great blog post](https://jstarry.notion.site/Transaction-confirmation-d5b8f4e09b9c4a70a1f263f82307d7ce) on this subject. In short, he recommends using `confirmed` over `finalized` to give transactions the greatest chance of confirming successfully.

> The "confirmed" commitment level should almost always be used for RPC requests ...
> Using the default commitment level "finalized" will eliminate any risk that the blockhash you choose will belong to a dropped fork. The tradeoff is that there is typically at least a 32 slot difference between the most recent confirmed block and the most recent finalized block. This tradeoff is pretty severe and effectively reduces the expiration of your transactions by about 13 seconds but this could be even more during unstable cluster conditions.

This PR implements @jstarry's recommended solution.