### PR TITLE
chore: adding the ‘Question’ tag now autocloses issues and directs the poster to Stack Exchange

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,27 @@
+question:
+  issues:
+    # Post a comment, `{issue-author}` is an optional placeholder
+    comment: >
+      Hi @{issue-author},
+
+
+      Thanks for your question!
+
+
+      We want to make sure to keep signal strong in the GitHub issue tracker &ndash; to make sure
+      that it remains the best place to track issues that affect the development of Solana itself.
+
+
+      Questions like yours deserve a purpose-built Q&A forum. Unless there exists evidence that
+      this is a bug with Solana itself, please post your question to the Solana Stack Exchange
+      using this link: https://solana.stackexchange.com/questions/ask
+
+      
+      ---
+
+      _This
+      [automated message](https://github.com/solana-labs/solana/blob/master/.github/label-actions.yml)
+      is a result of having added the &lsquo;question&rsquo; tag_.
+
+    # Close the issue
+    close: true

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,15 @@
+name: "Issue Label Actions"
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v2


### PR DESCRIPTION
#### Problem

We want to make it as easy as possible for core team members to nudge people over to Stack Exchange when questions that are not issues with Solana itself get posted to GitHub.

#### Summary of Changes

* Added a GitHub workflow to comment on and close issues when the `question` tag is added.