### PR TITLE
Fixing SolanaMobileWalletAdapter support

### DIFF
--- a/packages/starter/create-react-app-starter/src/App.tsx
+++ b/packages/starter/create-react-app-starter/src/App.tsx
@@ -39,6 +39,7 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
             new SolanaMobileWalletAdapter({
                 appIdentity: { name: 'Solana Create React App Starter App' },
                 authorizationResultCache: createDefaultAuthorizationResultCache(),
+                cluster: network
             }),
             new PhantomWalletAdapter(),
             new GlowWalletAdapter(),


### PR DESCRIPTION
fixing missing property `cluster` for type `appIdentity`