### PR TITLE
should not return after `wallet.connect()`

### DIFF
--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -112,7 +112,7 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             if (!wallet.isConnected) {
                 try {
-                    return await wallet.connect();
+                    await wallet.connect();
                 } catch (error: any) {
                     throw new WalletConnectionError(error?.message, error);
                 }


### PR DESCRIPTION
The `adapter.connect()` should just keep running and emit the `connect` event after calling `wallet.connect()`