### PR TITLE
React: Fix race condition in autoconnect

### DIFF
--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-react",
-    "version": "0.15.14",
+    "version": "0.15.15",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -155,7 +155,6 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     useEffect(() => {
         if (
             isConnecting.current ||
-            connecting ||
             connected ||
             !autoConnect ||
             !adapter ||
@@ -177,11 +176,11 @@ export const WalletProvider: FC<WalletProviderProps> = ({
                 isConnecting.current = false;
             }
         })();
-    }, [isConnecting, connecting, connected, autoConnect, adapter, readyState]);
+    }, [isConnecting, connected, autoConnect, adapter, readyState]);
 
     // Connect the adapter to the wallet
     const connect = useCallback(async () => {
-        if (isConnecting.current || connecting || disconnecting || connected) return;
+        if (isConnecting.current || isDisconnecting.current || connected) return;
         if (!adapter) throw handleError(new WalletNotSelectedError());
 
         if (!(readyState === WalletReadyState.Installed || readyState === WalletReadyState.Loadable)) {
@@ -208,11 +207,11 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             setConnecting(false);
             isConnecting.current = false;
         }
-    }, [isConnecting, connecting, disconnecting, connected, adapter, readyState, handleError]);
+    }, [isConnecting, isDisconnecting, connected, adapter, readyState, handleError]);
 
     // Disconnect the adapter from the wallet
     const disconnect = useCallback(async () => {
-        if (isDisconnecting.current || disconnecting) return;
+        if (isDisconnecting.current) return;
         if (!adapter) return setName(null);
 
         isDisconnecting.current = true;
@@ -228,7 +227,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
             setDisconnecting(false);
             isDisconnecting.current = false;
         }
-    }, [isDisconnecting, disconnecting, adapter]);
+    }, [isDisconnecting, adapter]);
 
     // Send a transaction using the provided connection
     const sendTransaction = useCallback(

--- a/packages/starter/create-react-app-starter/package.json
+++ b/packages/starter/create-react-app-starter/package.json
@@ -19,7 +19,7 @@
     ],
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.12",
-        "@solana/wallet-adapter-react": "^0.15.14",
+        "@solana/wallet-adapter-react": "^0.15.15",
         "@solana/wallet-adapter-react-ui": "^0.9.13",
         "@solana/wallet-adapter-wallets": "^0.18.1",
         "@solana/web3.js": "^1.50.1",

--- a/packages/starter/example/package.json
+++ b/packages/starter/example/package.json
@@ -35,7 +35,7 @@
         "@solana/wallet-adapter-ant-design": "^0.11.10",
         "@solana/wallet-adapter-base": "^0.9.12",
         "@solana/wallet-adapter-material-ui": "^0.16.11",
-        "@solana/wallet-adapter-react": "^0.15.14",
+        "@solana/wallet-adapter-react": "^0.15.15",
         "@solana/wallet-adapter-react-ui": "^0.9.13",
         "@solana/wallet-adapter-wallets": "^0.18.1",
         "@solana/web3.js": "^1.50.1",

--- a/packages/starter/material-ui-starter/package.json
+++ b/packages/starter/material-ui-starter/package.json
@@ -35,7 +35,7 @@
         "@mui/material": "^5.9.3",
         "@solana/wallet-adapter-base": "^0.9.12",
         "@solana/wallet-adapter-material-ui": "^0.16.11",
-        "@solana/wallet-adapter-react": "^0.15.14",
+        "@solana/wallet-adapter-react": "^0.15.15",
         "@solana/wallet-adapter-wallets": "^0.18.1",
         "@solana/web3.js": "^1.50.1",
         "notistack": "^2.0.0",

--- a/packages/starter/nextjs-starter/package.json
+++ b/packages/starter/nextjs-starter/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.12",
-        "@solana/wallet-adapter-react": "^0.15.14",
+        "@solana/wallet-adapter-react": "^0.15.15",
         "@solana/wallet-adapter-react-ui": "^0.9.13",
         "@solana/wallet-adapter-wallets": "^0.18.1",
         "next": "^12.2.3",

--- a/packages/starter/react-ui-starter/package.json
+++ b/packages/starter/react-ui-starter/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.12",
-        "@solana/wallet-adapter-react": "^0.15.14",
+        "@solana/wallet-adapter-react": "^0.15.15",
         "@solana/wallet-adapter-react-ui": "^0.9.13",
         "@solana/wallet-adapter-wallets": "^0.18.1",
         "@solana/web3.js": "^1.50.1",

--- a/packages/ui/ant-design/package.json
+++ b/packages/ui/ant-design/package.json
@@ -39,7 +39,7 @@
     "dependencies": {
         "@ant-design/icons": "^4.0.0",
         "@solana/wallet-adapter-base": "^0.9.12",
-        "@solana/wallet-adapter-react": "^0.15.14",
+        "@solana/wallet-adapter-react": "^0.15.15",
         "antd": "^4.22.3"
     },
     "devDependencies": {

--- a/packages/ui/material-ui/package.json
+++ b/packages/ui/material-ui/package.json
@@ -36,7 +36,7 @@
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.9.3",
         "@solana/wallet-adapter-base": "^0.9.12",
-        "@solana/wallet-adapter-react": "^0.15.14"
+        "@solana/wallet-adapter-react": "^0.15.15"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.50.1",

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.12",
-        "@solana/wallet-adapter-react": "^0.15.14"
+        "@solana/wallet-adapter-react": "^0.15.15"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.50.1",


### PR DESCRIPTION
The React autoconnect behavior has a race condition caused by the effect's dependency on the `connecting` state variable. When a wallet extension window is closed or connection is refused during autoconnect, it may run again and try to autoconnect to the same wallet. This is unrelated to the recent fix for #525.

This PR fixes this race condition and closes #519.