### PR TITLE
Support for strike wallet disconnecting

### DIFF
--- a/packages/wallets/strike/package.json
+++ b/packages/wallets/strike/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-strike",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "@solana/wallet-adapter-base": "workspace:^",
-        "@strike-protocols/solana-wallet-adapter": "^0.1.4"
+        "@strike-protocols/solana-wallet-adapter": "^0.1.7"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.61.0",

--- a/packages/wallets/strike/src/adapter.ts
+++ b/packages/wallets/strike/src/adapter.ts
@@ -88,6 +88,8 @@ export class StrikeWalletAdapter extends BaseSignerWalletAdapter {
                 throw new WalletConnectionError(error?.message, error);
             }
 
+            wallet.on('disconnect', this._disconnected);
+
             this._wallet = wallet;
             this._publicKey = publicKey;
 
@@ -103,6 +105,8 @@ export class StrikeWalletAdapter extends BaseSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
+            wallet.off('disconnect', this._disconnected);
+
             this._wallet = null;
             this._publicKey = null;
 
@@ -165,6 +169,19 @@ export class StrikeWalletAdapter extends BaseSignerWalletAdapter {
         } catch (error: any) {
             this.emit('error', error);
             throw error;
+        }
+    }
+
+    private _disconnected = () => {
+        const wallet = this._wallet;
+        if (wallet) {
+            wallet.off('disconnect', this._disconnected);
+
+            this._wallet = null;
+            this._publicKey = null;
+
+            this.emit('error', new WalletDisconnectedError());
+            this.emit('disconnect');
         }
     }
 }


### PR DESCRIPTION
Bumps `@strike-protocols/solana-wallet-adapter` version to 0.1.7, and adds support for the `disconnected` message it can now emit.