### PR TITLE
Fixing inline style for the react-ui WalletMultiButton

### DIFF
--- a/packages/ui/react-ui/src/Button.tsx
+++ b/packages/ui/react-ui/src/Button.tsx
@@ -16,7 +16,7 @@ export const Button: FC<ButtonProps> = (props) => {
         <button
             className={`wallet-adapter-button ${props.className || ''}`}
             disabled={props.disabled}
-            style={{...props.style}}
+            style={props.style}
             onClick={props.onClick}
             tabIndex={props.tabIndex || 0}
             type="button"

--- a/packages/ui/react-ui/src/Button.tsx
+++ b/packages/ui/react-ui/src/Button.tsx
@@ -16,6 +16,7 @@ export const Button: FC<ButtonProps> = (props) => {
         <button
             className={`wallet-adapter-button ${props.className || ''}`}
             disabled={props.disabled}
+            style={...props.style}
             onClick={props.onClick}
             tabIndex={props.tabIndex || 0}
             type="button"

--- a/packages/ui/react-ui/src/Button.tsx
+++ b/packages/ui/react-ui/src/Button.tsx
@@ -16,7 +16,7 @@ export const Button: FC<ButtonProps> = (props) => {
         <button
             className={`wallet-adapter-button ${props.className || ''}`}
             disabled={props.disabled}
-            style={...props.style}
+            style={{...props.style}}
             onClick={props.onClick}
             tabIndex={props.tabIndex || 0}
             type="button"


### PR DESCRIPTION
I recently realized that the style props of the WalletMultiButton wasn't working properly. It was not possible to override the styles.css by passing a backgroundColor, for example. That was happening because the style was not getting at the final component: Button.tsx

This is my first PR as a dev by the way 🥳 