### PR TITLE
Add versioned tx sending components to example app

### DIFF
--- a/packages/starter/example/src/components/SendLegacyTransaction.tsx
+++ b/packages/starter/example/src/components/SendLegacyTransaction.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mui/material';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
-import { TransactionMessage, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
+import type { TransactionSignature } from '@solana/web3.js';
+import { TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import type { FC } from 'react';
 import React, { useCallback } from 'react';
@@ -19,7 +20,10 @@ export const SendLegacyTransaction: FC = () => {
         }
 
         if (!supportedTransactionVersions) {
-            notify('error', 'Wallet doesn\'t support versioned transactions!');
+            notify('error', "Wallet doesn't support versioned transactions!");
+            return;
+        } else if (!supportedTransactionVersions.has('legacy')) {
+            notify('error', "Wallet doesn't support legacy transactions!");
             return;
         }
 
@@ -32,15 +36,18 @@ export const SendLegacyTransaction: FC = () => {
 
             const message = new TransactionMessage({
                 payerKey: publicKey,
-                instructions: [{
-                    data: Buffer.from('Hello, from the Solana Wallet Adapter example app!'),
-                    keys: [],
-                    programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
-                }],
+                instructions: [
+                    {
+                        data: Buffer.from('Hello, from the Solana Wallet Adapter example app!'),
+                        keys: [],
+                        programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+                    },
+                ],
                 recentBlockhash: blockhash,
             });
 
             const transaction = new VersionedTransaction(message.compileToLegacyMessage());
+
             signature = await sendTransaction(transaction, connection, { minContextSlot });
             notify('info', 'Transaction sent:', signature);
 
@@ -53,7 +60,12 @@ export const SendLegacyTransaction: FC = () => {
     }, [publicKey, notify, connection, sendTransaction, supportedTransactionVersions]);
 
     return (
-        <Button variant="contained" color="secondary" onClick={onClick} disabled={!publicKey || !supportedTransactionVersions}>
+        <Button
+            variant="contained"
+            color="secondary"
+            onClick={onClick}
+            disabled={!publicKey || !supportedTransactionVersions?.has('legacy')}
+        >
             Send Legacy Transaction (devnet)
         </Button>
     );

--- a/packages/starter/example/src/components/SendLegacyTransaction.tsx
+++ b/packages/starter/example/src/components/SendLegacyTransaction.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@mui/material';
+import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { AddressLookupTableAccount, MessageV0, TransactionMessage, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
+import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
+import type { FC } from 'react';
+import React, { useCallback } from 'react';
+import { useNotify } from './notify';
+
+export const SendLegacyTransaction: FC = () => {
+    const { connection } = useConnection();
+    const { publicKey, sendTransaction } = useWallet();
+    const notify = useNotify();
+
+    const onClick = useCallback(async () => {
+        if (!publicKey) {
+            notify('error', 'Wallet not connected!');
+            return;
+        }
+
+        let signature: TransactionSignature = '';
+        try {
+            const {
+                context: { slot: minContextSlot },
+                value: { blockhash, lastValidBlockHeight },
+            } = await connection.getLatestBlockhashAndContext();
+
+            const message = new TransactionMessage({
+                payerKey: publicKey,
+                instructions: [{
+                    data: Buffer.from('Hello, from the Solana Wallet Adapter example app!'),
+                    keys: [],
+                    programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+                }],
+                recentBlockhash: blockhash,
+            });
+
+            const transaction = new VersionedTransaction(message.compileToLegacyMessage());
+            signature = await sendTransaction(transaction, connection, { minContextSlot });
+            notify('info', 'Transaction sent:', signature);
+
+            await connection.confirmTransaction({ blockhash, lastValidBlockHeight, signature });
+            notify('success', 'Transaction successful!', signature);
+        } catch (error: any) {
+            notify('error', `Transaction failed! ${error?.message}`, signature);
+            return;
+        }
+    }, [publicKey, notify, connection, sendTransaction]);
+
+    return (
+        <Button variant="contained" color="secondary" onClick={onClick} disabled={!publicKey}>
+            Send Legacy Transaction (devnet)
+        </Button>
+    );
+};

--- a/packages/starter/example/src/components/SendLegacyTransaction.tsx
+++ b/packages/starter/example/src/components/SendLegacyTransaction.tsx
@@ -1,19 +1,25 @@
 import { Button } from '@mui/material';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
-import { AddressLookupTableAccount, MessageV0, TransactionMessage, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
-import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
+import { TransactionMessage, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { useNotify } from './notify';
 
 export const SendLegacyTransaction: FC = () => {
     const { connection } = useConnection();
-    const { publicKey, sendTransaction } = useWallet();
+    const { publicKey, sendTransaction, wallet } = useWallet();
     const notify = useNotify();
+    const supportedTransactionVersions = wallet?.adapter.supportedTransactionVersions;
 
     const onClick = useCallback(async () => {
         if (!publicKey) {
             notify('error', 'Wallet not connected!');
+            return;
+        }
+
+        if (!supportedTransactionVersions) {
+            notify('error', 'Wallet doesn\'t support versioned transactions!');
             return;
         }
 
@@ -44,10 +50,10 @@ export const SendLegacyTransaction: FC = () => {
             notify('error', `Transaction failed! ${error?.message}`, signature);
             return;
         }
-    }, [publicKey, notify, connection, sendTransaction]);
+    }, [publicKey, notify, connection, sendTransaction, supportedTransactionVersions]);
 
     return (
-        <Button variant="contained" color="secondary" onClick={onClick} disabled={!publicKey}>
+        <Button variant="contained" color="secondary" onClick={onClick} disabled={!publicKey || !supportedTransactionVersions}>
             Send Legacy Transaction (devnet)
         </Button>
     );

--- a/packages/starter/example/src/components/SendV0Transaction.tsx
+++ b/packages/starter/example/src/components/SendV0Transaction.tsx
@@ -28,6 +28,11 @@ export const SendV0Transaction: FC = () => {
 
         let signature: TransactionSignature = '';
         try {
+            /**
+             * This lookup table only exists on devnet and can be replaced as
+             * needed.  To create and manage a lookup table, use the `solana
+             * address-lookup-table` commands.
+             */
             const lookupTable = (await connection.getAddressLookupTable(new PublicKey("F3MfgEJe1TApJiA14nN2m4uAH4EBVrqdBnHeGeSXvQ7B"))).value;
             if (lookupTable === null) {
                 notify('error', 'Address lookup table wasn\'t found!');

--- a/packages/starter/example/src/components/SendV0Transaction.tsx
+++ b/packages/starter/example/src/components/SendV0Transaction.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mui/material';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
-import { AddressLookupTableAccount, TransactionMessage, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
-import { PublicKey } from '@solana/web3.js';
+import type { TransactionSignature } from '@solana/web3.js';
+import { PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { useNotify } from './notify';
@@ -19,10 +19,10 @@ export const SendV0Transaction: FC = () => {
         }
 
         if (!supportedTransactionVersions) {
-            notify('error', 'Wallet doesn\'t support versioned transactions!');
+            notify('error', "Wallet doesn't support versioned transactions!");
             return;
         } else if (!supportedTransactionVersions.has(0)) {
-            notify('error', 'Wallet doesn\'t support v0 transactions!');
+            notify('error', "Wallet doesn't support v0 transactions!");
             return;
         }
 
@@ -33,9 +33,11 @@ export const SendV0Transaction: FC = () => {
              * needed.  To create and manage a lookup table, use the `solana
              * address-lookup-table` commands.
              */
-            const lookupTable = (await connection.getAddressLookupTable(new PublicKey("F3MfgEJe1TApJiA14nN2m4uAH4EBVrqdBnHeGeSXvQ7B"))).value;
-            if (lookupTable === null) {
-                notify('error', 'Address lookup table wasn\'t found!');
+            const { value: lookupTable } = await connection.getAddressLookupTable(
+                new PublicKey('F3MfgEJe1TApJiA14nN2m4uAH4EBVrqdBnHeGeSXvQ7B')
+            );
+            if (!lookupTable) {
+                notify('error', "Address lookup table wasn't found!");
                 return;
             }
 
@@ -46,19 +48,21 @@ export const SendV0Transaction: FC = () => {
 
             const message = new TransactionMessage({
                 payerKey: publicKey,
-                instructions: [{
-                    data: Buffer.from('Hello, from the Solana Wallet Adapter example app!'),
-                    keys: lookupTable.state.addresses.map((pubkey, index) => ({
-                        pubkey,
-                        isWritable: index % 2 == 0,
-                        isSigner: false, 
-                    })),
-                    programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
-                }],
+                instructions: [
+                    {
+                        data: Buffer.from('Hello, from the Solana Wallet Adapter example app!'),
+                        keys: lookupTable.state.addresses.map((pubkey, index) => ({
+                            pubkey,
+                            isWritable: index % 2 == 0,
+                            isSigner: false,
+                        })),
+                        programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+                    },
+                ],
                 recentBlockhash: blockhash,
             });
 
-            const lookupTables: AddressLookupTableAccount[] = [lookupTable];
+            const lookupTables = [lookupTable];
             const transaction = new VersionedTransaction(message.compileToV0Message(lookupTables));
 
             signature = await sendTransaction(transaction, connection, { minContextSlot });
@@ -72,9 +76,13 @@ export const SendV0Transaction: FC = () => {
         }
     }, [publicKey, notify, connection, sendTransaction, supportedTransactionVersions]);
 
-    const disabled = !publicKey || !(supportedTransactionVersions && supportedTransactionVersions.has(0));
     return (
-        <Button variant="contained" color="secondary" onClick={onClick} disabled={disabled}>
+        <Button
+            variant="contained"
+            color="secondary"
+            onClick={onClick}
+            disabled={!publicKey || !supportedTransactionVersions?.has(0)}
+        >
             Send V0 Transaction using Address Lookup Table (devnet)
         </Button>
     );

--- a/packages/starter/example/src/components/SendV0Transaction.tsx
+++ b/packages/starter/example/src/components/SendV0Transaction.tsx
@@ -1,0 +1,66 @@
+import { Button } from '@mui/material';
+import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { AddressLookupTableAccount, AddressLookupTableInstruction, AddressLookupTableProgram, MessageV0, TransactionMessage, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
+import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
+import type { FC } from 'react';
+import React, { useCallback } from 'react';
+import { useNotify } from './notify';
+
+export const SendV0Transaction: FC = () => {
+    const { connection } = useConnection();
+    const { publicKey, sendTransaction } = useWallet();
+    const notify = useNotify();
+
+    const onClick = useCallback(async () => {
+        if (!publicKey) {
+            notify('error', 'Wallet not connected!');
+            return;
+        }
+
+        let signature: TransactionSignature = '';
+        try {
+            const lookupTable = (await connection.getAddressLookupTable(new PublicKey("F3MfgEJe1TApJiA14nN2m4uAH4EBVrqdBnHeGeSXvQ7B"))).value;
+            if (lookupTable === null) {
+                notify('error', 'Address lookup table wasn\'t found!');
+                return;
+            }
+
+            const {
+                context: { slot: minContextSlot },
+                value: { blockhash, lastValidBlockHeight },
+            } = await connection.getLatestBlockhashAndContext();
+
+            const message = new TransactionMessage({
+                payerKey: publicKey,
+                instructions: [{
+                    data: Buffer.from('Hello, from the Solana Wallet Adapter example app!'),
+                    keys: lookupTable.state.addresses.map((pubkey, index) => ({
+                        pubkey,
+                        isWritable: index % 2 == 0,
+                        isSigner: false, 
+                    })),
+                    programId: new PublicKey('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+                }],
+                recentBlockhash: blockhash,
+            });
+
+            const lookupTables: AddressLookupTableAccount[] = [lookupTable];
+            const transaction = new VersionedTransaction(message.compileToV0Message(lookupTables));
+
+            signature = await sendTransaction(transaction, connection, { minContextSlot });
+            notify('info', 'Transaction sent:', signature);
+
+            await connection.confirmTransaction({ blockhash, lastValidBlockHeight, signature });
+            notify('success', 'Transaction successful!', signature);
+        } catch (error: any) {
+            notify('error', `Transaction failed! ${error?.message}`, signature);
+            return;
+        }
+    }, [publicKey, notify, connection, sendTransaction]);
+
+    return (
+        <Button variant="contained" color="secondary" onClick={onClick} disabled={!publicKey}>
+            Send V0 Transaction using Address Lookup Table (devnet)
+        </Button>
+    );
+};

--- a/packages/starter/example/src/pages/index.tsx
+++ b/packages/starter/example/src/pages/index.tsx
@@ -123,13 +123,13 @@ const Index: NextPage = () => {
                 </TableRow>
                 <TableRow>
                     <TableCell></TableCell>
+                    <TableCell></TableCell>
                     <TableCell>
                         <SendLegacyTransaction />
                     </TableCell>
                     <TableCell>
                         <SendV0Transaction />
                     </TableCell>
-                    <TableCell></TableCell>
                     <TableCell></TableCell>
                 </TableRow>
             </TableBody>

--- a/packages/starter/example/src/pages/index.tsx
+++ b/packages/starter/example/src/pages/index.tsx
@@ -23,6 +23,8 @@ import pkg from '../../package.json';
 import { useAutoConnect } from '../components/AutoConnectProvider';
 import { RequestAirdrop } from '../components/RequestAirdrop';
 import { SendTransaction } from '../components/SendTransaction';
+import { SendLegacyTransaction } from '../components/SendLegacyTransaction';
+import { SendV0Transaction } from '../components/SendV0Transaction';
 import { SignMessage } from '../components/SignMessage';
 
 const Index: NextPage = () => {
@@ -118,6 +120,17 @@ const Index: NextPage = () => {
                     <TableCell>
                         <SignMessage />
                     </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell></TableCell>
+                    <TableCell>
+                        <SendLegacyTransaction />
+                    </TableCell>
+                    <TableCell>
+                        <SendV0Transaction />
+                    </TableCell>
+                    <TableCell></TableCell>
+                    <TableCell></TableCell>
                 </TableRow>
             </TableBody>
         </Table>


### PR DESCRIPTION
Add two components the example app for sending legacy and v0 transactions via the `VersionedTransaction` API. 

<img width="1144" alt="Screen Shot 2022-09-15 at 3 59 20 PM" src="https://user-images.githubusercontent.com/1076145/190497578-77aba67f-c3c0-4508-89ca-b7ae2e5de721.png">
