### PR TITLE
Adds Fractal Wallet Adapter Implementation

### DIFF
--- a/packages/wallets/fractal/LICENSE
+++ b/packages/wallets/fractal/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/wallets/fractal/README.md
+++ b/packages/wallets/fractal/README.md
@@ -1,0 +1,7 @@
+# `@solana/wallet-adapter-fractal`
+
+This package provides an adapter to enable solana dapps to connect to a Fractal Wallet.
+
+For quick setup, please refer to the solana-labs/wallet-adapter [README](https://github.com/solana-labs/wallet-adapter#quick-setup-using-react-ui)
+
+Integrating with [Fractal's Developer APIs and SDKs](https://developers.fractal.is) is the easiest way to build web3 games.

--- a/packages/wallets/fractal/package.json
+++ b/packages/wallets/fractal/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "@solana/wallet-adapter-fractal",
+    "version": "0.1.0",
+    "author": "Solana Maintainers <maintainers@solana.foundation>",
+    "repository": "https://github.com/solana-labs/wallet-adapter",
+    "license": "Apache-2.0",
+    "type": "module",
+    "sideEffects": false,
+    "engines": {
+        "node": ">=16"
+    },
+    "main": "./lib/cjs/index.js",
+    "module": "./lib/esm/index.js",
+    "types": "./lib/types/index.d.ts",
+    "exports": {
+        "require": "./lib/cjs/index.js",
+        "import": "./lib/esm/index.js",
+        "types": "./lib/types/index.d.ts"
+    },
+    "files": [
+        "lib",
+        "src",
+        "LICENSE"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "clean": "shx mkdir -p lib && shx rm -rf lib",
+        "package": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
+    },
+    "peerDependencies": {
+        "@solana/web3.js": "^1.61.0"
+    },
+    "dependencies": {
+        "@solana/wallet-adapter-base": "workspace:^"
+    },
+    "devDependencies": {
+        "@solana/web3.js": "^1.61.0",
+        "shx": "^0.3.4"
+    }
+}

--- a/packages/wallets/fractal/package.json
+++ b/packages/wallets/fractal/package.json
@@ -33,10 +33,14 @@
         "@solana/web3.js": "^1.61.0"
     },
     "dependencies": {
-        "@solana/wallet-adapter-base": "workspace:^"
+        "@fractalwagmi/popup-connection": "^1.0.10",
+        "@solana/wallet-adapter-base": "workspace:^",
+        "bs58": "^5.0.0",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.61.0",
+        "@types/uuid": "^8.3.4",
         "shx": "^0.3.4"
     }
 }

--- a/packages/wallets/fractal/src/adapter.ts
+++ b/packages/wallets/fractal/src/adapter.ts
@@ -1,0 +1,60 @@
+import type { SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import { BaseWalletAdapter, WalletReadyState } from '@solana/wallet-adapter-base';
+import type { Connection, Transaction, TransactionSignature } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
+
+export const FakeWalletName = 'Fake Wallet' as WalletName<'Fake Wallet'>;
+
+export class FakeWalletAdapter extends BaseWalletAdapter {
+    name = FakeWalletName;
+    url = 'https://github.com/solana-labs/wallet-adapter#usage';
+    icon =
+        'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzQiIGhlaWdodD0iMzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zNCAxMC42djIuN2wtOS41IDE2LjVoLTQuNmw2LTEwLjVhMi4xIDIuMSAwIDEgMCAyLTMuNGw0LjgtOC4zYTQgNCAwIDAgMSAxLjMgM1ptLTQuMyAxOS4xaC0uNmw0LjktOC40djQuMmMwIDIuMy0yIDQuMy00LjMgNC4zWm0yLTI4LjRjLS4zLS44LTEtMS4zLTItMS4zaC0xLjlsLTIuNCA0LjNIMzBsMS43LTNabS0zIDVoLTQuNkwxMC42IDI5LjhoNC43TDI4LjggNi40Wk0xOC43IDBoNC42bC0yLjUgNC4zaC00LjZMMTguNiAwWk0xNSA2LjRoNC42TDYgMjkuOEg0LjJjLS44IDAtMS43LS4zLTIuNC0uOEwxNSA2LjRaTTE0IDBIOS40TDcgNC4zaDQuNkwxNCAwWm0tMy42IDYuNEg1LjdMMCAxNi4ydjhMMTAuMyA2LjRaTTQuMyAwaC40TDAgOC4ydi00QzAgMiAxLjkgMCA0LjMgMFoiIGZpbGw9IiM5OTQ1RkYiLz48L3N2Zz4=';
+    readonly supportedTransactionVersions = null;
+    private _publicKey: PublicKey | null = null;
+
+    constructor() {
+        super();
+        console.warn(
+            'Your application is presently configured to use the `FakeWalletAdapter`. ' +
+                'Find and remove it, then replace it with a list of adapters for ' +
+                'wallets you would like your application to support. See ' +
+                'https://github.com/solana-labs/wallet-adapter#usage for an example.'
+        );
+    }
+
+    get connecting() {
+        return false;
+    }
+
+    get publicKey() {
+        return this._publicKey;
+    }
+
+    get readyState() {
+        return WalletReadyState.Installed;
+    }
+
+    async connect(): Promise<void> {
+        this._publicKey = PublicKey.default;
+        this.emit('connect', this._publicKey);
+    }
+
+    async disconnect(): Promise<void> {
+        this._publicKey = null;
+        this.emit('disconnect');
+    }
+
+    async sendTransaction(
+        transaction: Transaction,
+        connection: Connection,
+        options: SendTransactionOptions = {}
+    ): Promise<TransactionSignature> {
+        console.debug(
+            'FakeWallet: `sendTransaction()` was called. ' +
+                'Transaction was not actually sent to the network. ' +
+                'Returning `itsFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake` as the signature.'
+        );
+        return 'itsFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake';
+    }
+}

--- a/packages/wallets/fractal/src/adapter.ts
+++ b/packages/wallets/fractal/src/adapter.ts
@@ -3,24 +3,18 @@ import { BaseWalletAdapter, WalletReadyState } from '@solana/wallet-adapter-base
 import type { Connection, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
-export const FakeWalletName = 'Fake Wallet' as WalletName<'Fake Wallet'>;
+export const FractalWalletName = 'Fractal Wallet' as WalletName<'Fractal Wallet'>;
 
-export class FakeWalletAdapter extends BaseWalletAdapter {
-    name = FakeWalletName;
+export class FractalWalletAdapter extends BaseWalletAdapter {
+    name = FractalWalletName;
     url = 'https://github.com/solana-labs/wallet-adapter#usage';
     icon =
-        'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzQiIGhlaWdodD0iMzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zNCAxMC42djIuN2wtOS41IDE2LjVoLTQuNmw2LTEwLjVhMi4xIDIuMSAwIDEgMCAyLTMuNGw0LjgtOC4zYTQgNCAwIDAgMSAxLjMgM1ptLTQuMyAxOS4xaC0uNmw0LjktOC40djQuMmMwIDIuMy0yIDQuMy00LjMgNC4zWm0yLTI4LjRjLS4zLS44LTEtMS4zLTItMS4zaC0xLjlsLTIuNCA0LjNIMzBsMS43LTNabS0zIDVoLTQuNkwxMC42IDI5LjhoNC43TDI4LjggNi40Wk0xOC43IDBoNC42bC0yLjUgNC4zaC00LjZMMTguNiAwWk0xNSA2LjRoNC42TDYgMjkuOEg0LjJjLS44IDAtMS43LS4zLTIuNC0uOEwxNSA2LjRaTTE0IDBIOS40TDcgNC4zaDQuNkwxNCAwWm0tMy42IDYuNEg1LjdMMCAxNi4ydjhMMTAuMyA2LjRaTTQuMyAwaC40TDAgOC4ydi00QzAgMiAxLjkgMCA0LjMgMFoiIGZpbGw9IiM5OTQ1RkYiLz48L3N2Zz4=';
+        'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAwIDEwMDAiPjxwYXRoIGQ9Ik0zNDIuMjQgNzYzLjkzVjI0My44Mkg3MTV2MTEyLjY5SDQ4MXYxMTUuNThoMTgydjExMi42OUg0ODF2MTc5LjE1WiIgc3R5bGU9ImZpbGw6I2RlMzU5YyIvPjwvc3ZnPg==';
     readonly supportedTransactionVersions = null;
     private _publicKey: PublicKey | null = null;
 
     constructor() {
         super();
-        console.warn(
-            'Your application is presently configured to use the `FakeWalletAdapter`. ' +
-                'Find and remove it, then replace it with a list of adapters for ' +
-                'wallets you would like your application to support. See ' +
-                'https://github.com/solana-labs/wallet-adapter#usage for an example.'
-        );
     }
 
     get connecting() {

--- a/packages/wallets/fractal/src/adapter.ts
+++ b/packages/wallets/fractal/src/adapter.ts
@@ -1,24 +1,55 @@
-import type { SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
-import { BaseWalletAdapter, WalletReadyState } from '@solana/wallet-adapter-base';
-import type { Connection, Transaction, TransactionSignature } from '@solana/web3.js';
+import base58 from 'bs58';
+import {
+    SendTransactionOptions,
+    TransactionOrVersionedTransaction,
+    WalletError,
+    WalletNotConnectedError,
+    WalletSignTransactionError,
+} from '@solana/wallet-adapter-base';
+import type { WalletName } from '@solana/wallet-adapter-base';
+import {
+    BaseSignerWalletAdapter,
+    WalletReadyState,
+    WalletConnectionError,
+    WalletPublicKeyError,
+    WalletNotReadyError,
+} from '@solana/wallet-adapter-base';
+import { Message, Transaction } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
+import {
+    ConnectionManager,
+    Platform,
+    PopupEvent,
+    assertPayloadIsSolanaWalletAdapterApproved,
+    DEFAULT_POPUP_HEIGHT_PX,
+    assertPayloadIsTransactionSignatureNeededResponsePayload,
+} from '@fractalwagmi/popup-connection';
+import type { TransactionSignatureNeededPayload } from '@fractalwagmi/popup-connection';
+import uuid from 'uuid';
+
+const FRACTAL_DOMAIN_HTTPS = 'https://fractal.is';
+const MIN_POPUP_HEIGHT_PX = DEFAULT_POPUP_HEIGHT_PX;
+const MAX_POPUP_WIDTH_PX = 850;
 
 export const FractalWalletName = 'Fractal Wallet' as WalletName<'Fractal Wallet'>;
 
-export class FractalWalletAdapter extends BaseWalletAdapter {
+export class FractalWalletAdapter extends BaseSignerWalletAdapter {
     name = FractalWalletName;
     url = 'https://github.com/solana-labs/wallet-adapter#usage';
     icon =
         'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAwIDEwMDAiPjxwYXRoIGQ9Ik0zNDIuMjQgNzYzLjkzVjI0My44Mkg3MTV2MTEyLjY5SDQ4MXYxMTUuNThoMTgydjExMi42OUg0ODF2MTc5LjE1WiIgc3R5bGU9ImZpbGw6I2RlMzU5YyIvPjwvc3ZnPg==';
-    readonly supportedTransactionVersions = null;
     private _publicKey: PublicKey | null = null;
+    private _connecting = false;
+    readonly supportedTransactionVersions = null;
+
+    private popupManager = new ConnectionManager(Platform.SOLANA_WALLET_ADAPTER);
 
     constructor() {
         super();
     }
 
     get connecting() {
-        return false;
+        return this._connecting;
     }
 
     get publicKey() {
@@ -26,29 +57,151 @@ export class FractalWalletAdapter extends BaseWalletAdapter {
     }
 
     get readyState() {
-        return WalletReadyState.Installed;
+        return WalletReadyState.Loadable;
     }
 
     async connect(): Promise<void> {
+        let resolve: () => void | undefined;
+        let reject: (err: unknown) => void | undefined;
         this._publicKey = PublicKey.default;
-        this.emit('connect', this._publicKey);
+        const nonce = uuid.v4();
+        this._connecting = true;
+        this.popupManager.open({
+            url: `${FRACTAL_DOMAIN_HTTPS}/wallet-adapter/approve/${nonce}`,
+            nonce,
+        });
+
+        const handleSolanaWalletAdapterApproved = (payload: unknown) => {
+            if (!assertPayloadIsSolanaWalletAdapterApproved(payload)) {
+                reject(
+                    new WalletConnectionError(
+                        'Malformed payload when setting up connection. ' +
+                            'Expected { solanaPublicKey: string } but ' +
+                            `received ${payload}`
+                    )
+                );
+                return;
+            }
+            try {
+                this._publicKey = new PublicKey(payload.solanaPublicKey);
+                resolve();
+                this.emit('connect', this._publicKey);
+            } catch (error: any) {
+                const publicKeyError = new WalletPublicKeyError(error?.message, error);
+                reject(publicKeyError);
+                this.emit('error', publicKeyError);
+            }
+            this._connecting = false;
+        };
+
+        this.popupManager.onConnectionUpdated((connection) => {
+            if (!connection) {
+                return;
+            }
+            connection.on(PopupEvent.SOLANA_WALLET_ADAPTER_APPROVED, handleSolanaWalletAdapterApproved);
+        });
+
+        return new Promise((promiseResolver, promiseRejector) => {
+            resolve = promiseResolver;
+            reject = promiseRejector;
+        });
     }
 
     async disconnect(): Promise<void> {
+        this.popupManager.tearDown();
         this._publicKey = null;
         this.emit('disconnect');
     }
 
-    async sendTransaction(
-        transaction: Transaction,
-        connection: Connection,
-        options: SendTransactionOptions = {}
-    ): Promise<TransactionSignature> {
-        console.debug(
-            'FakeWallet: `sendTransaction()` was called. ' +
-                'Transaction was not actually sent to the network. ' +
-                'Returning `itsFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake` as the signature.'
-        );
-        return 'itsFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake';
+    async signTransaction<T extends Transaction>(transaction: T): Promise<T> {
+        try {
+            this.checkWalletReadiness();
+            const result = await this.signTransactions([transaction]);
+            return result[0];
+        } catch (error: any) {
+            let errorToThrow = error;
+            if (!(error instanceof WalletError)) {
+                errorToThrow = new WalletSignTransactionError(error?.message, error);
+            }
+            this.emit('error', errorToThrow);
+            throw error;
+        }
+    }
+
+    async signAllTransactions<T extends Transaction>(transactions: T[]): Promise<T[]> {
+        try {
+            this.checkWalletReadiness();
+            const result = await this.signTransactions(transactions);
+            return result;
+        } catch (error: any) {
+            let errorToThrow = error;
+            if (!(error instanceof WalletError)) {
+                errorToThrow = new WalletSignTransactionError(error?.message, error);
+            }
+            this.emit('error', errorToThrow);
+            throw error;
+        }
+    }
+
+    private async signTransactions<T extends Transaction>(transactions: T[]): Promise<T[]> {
+        let resolve: (signedTransactions: T[]) => void;
+        let reject: (err: WalletError) => void;
+
+        const handleTransactionSignatureNeededResponse = (payload: unknown) => {
+            if (!assertPayloadIsTransactionSignatureNeededResponsePayload(payload)) {
+                const error = new WalletSignTransactionError(
+                    'Malformed payload when signing transactions. ' +
+                        'Expected { signedB58Transactions: string[] } ' +
+                        `but received ${payload}`
+                );
+                reject(error);
+                this.emit('error', error);
+                return;
+            }
+
+            const signedTransactions = payload.signedB58Transactions.map((signedB58Transaction) => {
+                const message = Message.from(base58.decode(signedB58Transaction));
+                return Transaction.populate(message);
+            }) as T[];
+
+            resolve(signedTransactions);
+        };
+
+        const nonce = uuid.v4();
+        this.popupManager.open({
+            url: `${FRACTAL_DOMAIN_HTTPS}/wallet-adapter/sign/${nonce}`,
+            nonce,
+            heightPx: Math.max(MIN_POPUP_HEIGHT_PX, Math.floor(window.innerHeight * 0.8)),
+            widthPx: Math.min(MAX_POPUP_WIDTH_PX, Math.floor(window.innerWidth * 0.8)),
+        });
+        this.popupManager.onConnectionUpdated((connection) => {
+            if (!connection) {
+                return;
+            }
+
+            connection.on(PopupEvent.TRANSACTION_SIGNATURE_NEEDED_RESPONSE, handleTransactionSignatureNeededResponse);
+
+            const payload: TransactionSignatureNeededPayload = {
+                unsignedB58Transactions: transactions.map((t) => base58.encode(t.serializeMessage())),
+            };
+            connection.send({
+                event: PopupEvent.TRANSACTION_SIGNATURE_NEEDED,
+                payload,
+            });
+        });
+
+        return new Promise<T[]>((promiseResolver, promiseRejector) => {
+            resolve = promiseResolver;
+            reject = promiseRejector;
+        });
+    }
+
+    private checkWalletReadiness() {
+        if (this.publicKey === null) {
+            throw new WalletNotConnectedError('`publicKey` is null. Did you forget to call `.connect()`?');
+        }
+        if (this.connecting) {
+            throw new WalletNotReadyError('`signTransaction` cannot be called while connecting');
+        }
     }
 }

--- a/packages/wallets/fractal/src/index.ts
+++ b/packages/wallets/fractal/src/index.ts
@@ -1,0 +1,1 @@
+export * from './adapter.js';

--- a/packages/wallets/fractal/tsconfig.all.json
+++ b/packages/wallets/fractal/tsconfig.all.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../../tsconfig.root.json",
+    "references": [
+        {
+            "path": "../../core/base/tsconfig.all.json"
+        },
+        {
+            "path": "./tsconfig.cjs.json"
+        },
+        {
+            "path": "./tsconfig.esm.json"
+        }
+    ]
+}

--- a/packages/wallets/fractal/tsconfig.cjs.json
+++ b/packages/wallets/fractal/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../../tsconfig.cjs.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "outDir": "lib/cjs"
+    }
+}

--- a/packages/wallets/fractal/tsconfig.esm.json
+++ b/packages/wallets/fractal/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../../tsconfig.esm.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "outDir": "lib/esm",
+        "declarationDir": "lib/types"
+    }
+}


### PR DESCRIPTION
Hey folks at Solana labs. This is an adapter for Fractal wallets and extends on the original PR from @kcking: #387.

Some context:

Fractal wallet is non-custodial, so the private keys for signing transactions are only available when an authenticated user visits `fractal.is`. We don't store the user's keypair in any capacity on our end, so signing can only be done while a user visits fractal.is

For this reason, the `connect` function essentially opens a popup and asks for user approval to share their public key with the requesting domain (whatever domain the dapp is hosted on that's running fractal wallet adapter.)

Same thing goes for the `signTransaction` and `signAllTransactions` methods -- these are re-implemented using a custom sign-transactions page on fractal.is that's opened in a popup and the user can approve those transactions.

Please let me know if this makes sense.

Also, could you let me know how I can publish a private version of this repo to test this end-to-end? We can publish this private version in our npm namespace: `@fractalwagmi/some-package-name`.