### PR TITLE
Open ecosystem page when no mobile wallets respond

### DIFF
--- a/packages/core/react/__mocks__/@solana-mobile/wallet-adapter-mobile.ts
+++ b/packages/core/react/__mocks__/@solana-mobile/wallet-adapter-mobile.ts
@@ -4,6 +4,7 @@ import { MockWalletAdapter } from '../../src/__mocks__/MockWalletAdapter.js';
 export const SolanaMobileWalletAdapterWalletName = 'Solana Mobile Wallet Adapter Name For Tests';
 export const createDefaultAddressSelector = jest.fn();
 export const createDefaultAuthorizationResultCache = jest.fn();
+export const createDefaultWalletNotFoundHandler = jest.fn();
 
 class MockSolanaMobileWalletAdapter extends MockWalletAdapter {
     autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = jest.fn();

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -35,7 +35,7 @@
         "react": "*"
     },
     "dependencies": {
-        "@solana-mobile/wallet-adapter-mobile": "^0.9.4",
+        "@solana-mobile/wallet-adapter-mobile": "^0.9.5",
         "@solana/wallet-adapter-base": "workspace:^",
         "@wallet-standard/solana-wallet-adapter-react": "^0.1.0-alpha.8"
     },

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -1,6 +1,7 @@
 import {
     createDefaultAddressSelector,
     createDefaultAuthorizationResultCache,
+    createDefaultWalletNotFoundHandler,
     SolanaMobileWalletAdapter,
     SolanaMobileWalletAdapterWalletName,
 } from '@solana-mobile/wallet-adapter-mobile';
@@ -68,6 +69,7 @@ export function WalletProvider({
             },
             authorizationResultCache: createDefaultAuthorizationResultCache(),
             cluster: getInferredClusterFromEndpoint(connection?.rpcEndpoint),
+            onWalletNotFound: createDefaultWalletNotFoundHandler(),
         });
     }, [adaptersWithStandardAdapters, connection?.rpcEndpoint]);
     const adaptersWithMobileWalletAdapter = useMemo(() => {

--- a/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
@@ -150,6 +150,7 @@ describe('WalletProvider when the environment is `DESKTOP_WEB`', () => {
                 appIdentity: CUSTOM_APP_IDENTITY,
                 authorizationResultCache: jest.fn() as unknown as AuthorizationResultCache,
                 cluster: CUSTOM_CLUSTER,
+                onWalletNotFound: jest.fn(),
             });
             adapters.push(customAdapter);
             jest.clearAllMocks();

--- a/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
@@ -202,6 +202,7 @@ describe('WalletProvider when the environment is `MOBILE_WEB`', () => {
                 appIdentity: CUSTOM_APP_IDENTITY,
                 authorizationResultCache: jest.fn() as unknown as AuthorizationResultCache,
                 cluster: CUSTOM_CLUSTER,
+                onWalletNotFound: jest.fn(),
             });
             adapters.push(customAdapter);
             jest.clearAllMocks();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       eslint-plugin-react-hooks: ^4.6.0
       eslint-plugin-require-extensions: ^0.1.1
       gh-pages: ^4.0.0
-      pnpm: ^7.13.0
+      pnpm: ^7.13.4
       prettier: ^2.7.1
       shx: ^0.3.4
       typedoc: ^0.23.10
@@ -58,7 +58,7 @@ importers:
   packages/core/react:
     specifiers:
       '@solana-mobile/mobile-wallet-adapter-protocol': ^0.9.4
-      '@solana-mobile/wallet-adapter-mobile': ^0.9.4
+      '@solana-mobile/wallet-adapter-mobile': ^0.9.5
       '@solana/wallet-adapter-base': workspace:^
       '@solana/web3.js': ^1.61.0
       '@types/jest': ^28.1.6
@@ -73,7 +73,7 @@ importers:
       shx: ^0.3.4
       ts-jest: ^28.0.8
     dependencies:
-      '@solana-mobile/wallet-adapter-mobile': 0.9.4_wflj42ferjjaggu4kvovfbjbcy
+      '@solana-mobile/wallet-adapter-mobile': 0.9.5_wflj42ferjjaggu4kvovfbjbcy
       '@solana/wallet-adapter-base': link:../base
       '@wallet-standard/solana-wallet-adapter-react': 0.1.0-alpha.8_6m273jeabj4h6sjnlmfgvycgyu
     devDependencies:
@@ -123,7 +123,7 @@ importers:
       react: 18.2.0
       react-app-rewired: 2.2.1_react-scripts@5.0.1
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_yj7xztyo4flup4zk6yj3sg7fka
+      react-scripts: 5.0.1_n7mqr4n4gswjc26jfdbklgbjf4
       web-vitals: 2.1.4
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
@@ -172,8 +172,8 @@ importers:
       typescript: ~4.7.4
     dependencies:
       '@ant-design/icons': 4.7.0_biqbaboplfbrettd7655fr4n2y
-      '@emotion/react': 11.10.4_iapumuv4e6jcjznwuxpf4tt22e
-      '@emotion/styled': 11.10.4_g3tud4ene45llglqap74b5kkse
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
+      '@emotion/styled': 11.10.4_ogudqqhlstsi7uge4lir7ff3ty
       '@mui/icons-material': 5.10.9_6usjrp3ypnzobhq35dcwvjrt3m
       '@mui/material': 5.10.9_ikcgkdnp4bn3rgptamntbhbo7e
       '@solana/wallet-adapter-ant-design': link:../../ui/ant-design
@@ -185,7 +185,7 @@ importers:
       '@solana/web3.js': 1.65.0
       antd: 4.23.5_biqbaboplfbrettd7655fr4n2y
       bs58: 4.0.1
-      next: 12.2.0_biqbaboplfbrettd7655fr4n2y
+      next: 12.2.0_6tziyx3dehkoeijunclpkpolha
       notistack: 2.0.5_o5fu5zzztezljyppmu7zljxb6q
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -224,8 +224,8 @@ importers:
       shx: ^0.3.4
       typescript: ~4.7.4
     dependencies:
-      '@emotion/react': 11.10.4_iapumuv4e6jcjznwuxpf4tt22e
-      '@emotion/styled': 11.10.4_g3tud4ene45llglqap74b5kkse
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
+      '@emotion/styled': 11.10.4_ogudqqhlstsi7uge4lir7ff3ty
       '@mui/icons-material': 5.10.9_6usjrp3ypnzobhq35dcwvjrt3m
       '@mui/material': 5.10.9_ikcgkdnp4bn3rgptamntbhbo7e
       '@solana/wallet-adapter-base': link:../../core/base
@@ -1677,15 +1677,6 @@ packages:
       '@babel/core': 7.19.3
       '@babel/helper-plugin-utils': 7.19.0
 
-  /@babel/plugin-syntax-jsx/7.18.6:
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.19.0
-    dev: false
-
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.19.3:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
@@ -2588,25 +2579,6 @@ packages:
     resolution: {integrity: sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==}
     engines: {node: '>=10'}
 
-  /@emotion/babel-plugin/11.10.2:
-    resolution: {integrity: sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6
-      '@babel/runtime': 7.19.4
-      '@emotion/hash': 0.9.0
-      '@emotion/memoize': 0.8.0
-      '@emotion/serialize': 1.1.0
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.0.13
-    dev: false
-
   /@emotion/babel-plugin/11.10.2_@babel+core@7.19.3:
     resolution: {integrity: sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==}
     peerDependencies:
@@ -2670,30 +2642,6 @@ packages:
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
 
-  /@emotion/react/11.10.4_iapumuv4e6jcjznwuxpf4tt22e:
-    resolution: {integrity: sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.19.4
-      '@emotion/babel-plugin': 11.10.2
-      '@emotion/cache': 11.10.3
-      '@emotion/serialize': 1.1.0
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
-      '@emotion/utils': 1.2.0
-      '@emotion/weak-memoize': 0.3.0
-      '@types/react': 18.0.21
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    dev: false
-
   /@emotion/serialize/1.1.0:
     resolution: {integrity: sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==}
     dependencies:
@@ -2705,30 +2653,6 @@ packages:
 
   /@emotion/sheet/1.2.0:
     resolution: {integrity: sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==}
-
-  /@emotion/styled/11.10.4_g3tud4ene45llglqap74b5kkse:
-    resolution: {integrity: sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@emotion/react': ^11.0.0-rc.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.19.4
-      '@emotion/babel-plugin': 11.10.2
-      '@emotion/is-prop-valid': 1.2.0
-      '@emotion/react': 11.10.4_iapumuv4e6jcjznwuxpf4tt22e
-      '@emotion/serialize': 1.1.0
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
-      '@emotion/utils': 1.2.0
-      '@types/react': 18.0.21
-      react: 18.2.0
-    dev: false
 
   /@emotion/styled/11.10.4_ogudqqhlstsi7uge4lir7ff3ty:
     resolution: {integrity: sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==}
@@ -4771,7 +4695,7 @@ packages:
       react-native: ^0.0.0-0 || 0.60 - 0.70 || 1000.0.0
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.70.3_l7pre6hb4rf5lokhq3umcfwfl4
+      react-native: 0.70.3_sxyvc5w76clw6xultp2jaqrfwi
     dev: false
 
   /@react-native-community/cli-clean/9.1.0:
@@ -4859,7 +4783,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@react-native-community/cli-plugin-metro/9.1.3:
+  /@react-native-community/cli-plugin-metro/9.1.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-eLZiGIMybNwkbfKRd8wfNP1u5pnsGYLD3YHlNQyRlfS7AMG7NCQN8bk2uWWJJmWAv632KFLConwJGcLhk6ZNMQ==}
     dependencies:
       '@react-native-community/cli-server-api': 9.1.0
@@ -4868,11 +4792,12 @@ packages:
       metro: 0.72.3
       metro-config: 0.72.3
       metro-core: 0.72.3
-      metro-react-native-babel-transformer: 0.72.3
+      metro-react-native-babel-transformer: 0.72.3_@babel+core@7.19.3
       metro-resolver: 0.72.3
       metro-runtime: 0.72.3
       readline: 1.3.0
     transitivePeerDependencies:
+      - '@babel/core'
       - bufferutil
       - encoding
       - supports-color
@@ -4916,7 +4841,7 @@ packages:
     dependencies:
       joi: 17.6.3
 
-  /@react-native-community/cli/9.1.3:
+  /@react-native-community/cli/9.1.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-dfiBxNvqSwxkMduH0eAEJNS+LBbwxm1rOlTO7bN+FZvUwZNCCgIYrixfRo+ifqDUv8N5AbpQB5umnLbs0AjPaA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -4926,7 +4851,7 @@ packages:
       '@react-native-community/cli-debugger-ui': 9.0.0
       '@react-native-community/cli-doctor': 9.1.2
       '@react-native-community/cli-hermes': 9.1.0
-      '@react-native-community/cli-plugin-metro': 9.1.3
+      '@react-native-community/cli-plugin-metro': 9.1.3_@babel+core@7.19.3
       '@react-native-community/cli-server-api': 9.1.0
       '@react-native-community/cli-tools': 9.1.0
       '@react-native-community/cli-types': 9.1.0
@@ -4939,6 +4864,7 @@ packages:
       prompts: 2.4.2
       semver: 6.3.0
     transitivePeerDependencies:
+      - '@babel/core'
       - bufferutil
       - encoding
       - supports-color
@@ -5045,12 +4971,12 @@ packages:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: false
 
-  /@solana-mobile/mobile-wallet-adapter-protocol-web3js/0.9.4_wflj42ferjjaggu4kvovfbjbcy:
-    resolution: {integrity: sha512-pqy9C7nQKtqn3exwx39FLNs1iEQ5veuME0vAQ3vCttX6SdY1Qc5Uvogc63QzL2Anr7GUxgSOT7GbwiS9Z187Uw==}
+  /@solana-mobile/mobile-wallet-adapter-protocol-web3js/0.9.5_wflj42ferjjaggu4kvovfbjbcy:
+    resolution: {integrity: sha512-fGwhUwDWNdBzTLEQwR3r3ATlJ41IIu1fPQs6rLtkdPMIrZz1hrfLxmkiHUCvL0QPBTXD8RfTq6a29lbpBDWmhw==}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 0.9.4_react-native@0.70.3
+      '@solana-mobile/mobile-wallet-adapter-protocol': 0.9.5_react-native@0.70.3
       '@solana/web3.js': 1.65.0
       bs58: 5.0.0
       js-base64: 3.7.2
@@ -5063,15 +4989,24 @@ packages:
     peerDependencies:
       react-native: '>0.69'
     dependencies:
-      react-native: 0.70.3_l7pre6hb4rf5lokhq3umcfwfl4
+      react-native: 0.70.3_sxyvc5w76clw6xultp2jaqrfwi
+    dev: true
 
-  /@solana-mobile/wallet-adapter-mobile/0.9.4_wflj42ferjjaggu4kvovfbjbcy:
-    resolution: {integrity: sha512-37xiNdFjw9v2Ovu5tvflBfZcRkk1EzqvrJ6WHZ134OFSiRBcF26QmzbQ2s4SfL2cUcLoSWBp7OzlggunYxyDZA==}
+  /@solana-mobile/mobile-wallet-adapter-protocol/0.9.5_react-native@0.70.3:
+    resolution: {integrity: sha512-scF/2b6ekG9zHxgjQoGxWFFsWJeC7eDDH0tebTigPn0oqV8LKmM81solwa3GmAjUoSSPtnvC9XLrRcSCd/HHdg==}
+    peerDependencies:
+      react-native: '>0.69'
+    dependencies:
+      react-native: 0.70.3_sxyvc5w76clw6xultp2jaqrfwi
+    dev: false
+
+  /@solana-mobile/wallet-adapter-mobile/0.9.5_wflj42ferjjaggu4kvovfbjbcy:
+    resolution: {integrity: sha512-LSrk/p7qgjT6bFsxs7mZXAP9ELxxXDvB6j+LXsH9mFGNN5W/MrcWiyUzlxO6mB/l99czOy2cjLILh4jP5DYlNw==}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
       '@react-native-async-storage/async-storage': 1.17.10_react-native@0.70.3
-      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 0.9.4_wflj42ferjjaggu4kvovfbjbcy
+      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 0.9.5_wflj42ferjjaggu4kvovfbjbcy
       '@solana/wallet-adapter-base': 0.9.18_@solana+web3.js@1.65.0
       '@solana/web3.js': 1.65.0
       js-base64: 3.7.2
@@ -6575,8 +6510,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -8955,7 +8892,7 @@ packages:
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1_2iahngt3u2tkbdlu6s4gkur3pu
-      eslint-plugin-import: 2.26.0_acdrj6ev3m2ywvsf3jx7yuzdgm
+      eslint-plugin-import: 2.26.0_eslint@8.22.0
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.22.0
       eslint-plugin-react: 7.31.10_eslint@8.22.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.22.0
@@ -9026,7 +8963,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 8.22.0
-      eslint-plugin-import: 2.26.0_acdrj6ev3m2ywvsf3jx7yuzdgm
+      eslint-plugin-import: 2.26.0_eslint@8.22.0
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.1
@@ -9064,7 +9001,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.4_hi5wenbxw5l32qty4nuis7j6zi:
+  /eslint-module-utils/2.7.4_7gfxlqsjhuntdifxknjgbjwpbu:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9085,11 +9022,9 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       debug: 3.2.7
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_2iahngt3u2tkbdlu6s4gkur3pu
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9109,7 +9044,7 @@ packages:
       string-natural-compare: 3.0.1
     dev: false
 
-  /eslint-plugin-import/2.26.0_acdrj6ev3m2ywvsf3jx7yuzdgm:
+  /eslint-plugin-import/2.26.0_eslint@8.22.0:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9119,14 +9054,13 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_hi5wenbxw5l32qty4nuis7j6zi
+      eslint-module-utils: 2.7.4_7gfxlqsjhuntdifxknjgbjwpbu
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -10967,13 +10901,13 @@ packages:
       '@types/connect': 3.4.35
       '@types/node': 12.20.55
       '@types/ws': 7.4.7
+      JSONStream: 1.3.5
       commander: 2.20.3
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
       isomorphic-ws: 4.0.1_ws@7.5.9
       json-stringify-safe: 5.0.1
-      JSONStream: 1.3.5
       lodash: 4.17.21
       uuid: 8.3.2
       ws: 7.5.9
@@ -12736,8 +12670,10 @@ packages:
     dependencies:
       uglify-es: 3.3.9
 
-  /metro-react-native-babel-preset/0.72.3:
+  /metro-react-native-babel-preset/0.72.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-uJx9y/1NIqoYTp6ZW1osJ7U5ZrXGAJbOQ/Qzl05BdGYvN1S7Qmbzid6xOirgK0EIT0pJKEEh1s8qbassYZe4cw==}
+    peerDependencies:
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.19.3
       '@babel/plugin-proposal-async-generator-functions': 7.19.1_@babel+core@7.19.3
@@ -12781,14 +12717,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /metro-react-native-babel-transformer/0.72.3:
+  /metro-react-native-babel-transformer/0.72.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-Ogst/M6ujYrl/+9mpEWqE3zF7l2mTuftDTy3L8wZYwX1pWUQWQpfU1aJBeWiLxt1XlIq+uriRjKzKoRoIK57EA==}
+    peerDependencies:
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.19.3
       babel-preset-fbjs: 3.4.0_@babel+core@7.19.3
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.72.3
-      metro-react-native-babel-preset: 0.72.3
+      metro-react-native-babel-preset: 0.72.3_@babel+core@7.19.3
       metro-source-map: 0.72.3
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -12902,7 +12840,7 @@ packages:
       metro-hermes-compiler: 0.72.3
       metro-inspector-proxy: 0.72.3
       metro-minify-uglify: 0.72.3
-      metro-react-native-babel-preset: 0.72.3
+      metro-react-native-babel-preset: 0.72.3_@babel+core@7.19.3
       metro-resolver: 0.72.3
       metro-runtime: 0.72.3
       metro-source-map: 0.72.3
@@ -13161,7 +13099,7 @@ packages:
       - webpack
     dev: true
 
-  /next/12.2.0_biqbaboplfbrettd7655fr4n2y:
+  /next/12.2.0_6tziyx3dehkoeijunclpkpolha:
     resolution: {integrity: sha512-B4j7D3SHYopLYx6/Ark0fenwIar9tEaZZFAaxmKjgcMMexhVJzB3jt7X+6wcdXPPMeUD6r09weUtnDpjox/vIA==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -13185,7 +13123,7 @@ packages:
       postcss: 8.4.5
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.0.2_react@18.2.0
+      styled-jsx: 5.0.2_b6k74wvxdvqypha4emuv7fd2ke
       use-sync-external-store: 1.1.0_react@18.2.0
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.2.0
@@ -13346,8 +13284,8 @@ packages:
       '@emotion/styled':
         optional: true
     dependencies:
-      '@emotion/react': 11.10.4_iapumuv4e6jcjznwuxpf4tt22e
-      '@emotion/styled': 11.10.4_g3tud4ene45llglqap74b5kkse
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
+      '@emotion/styled': 11.10.4_ogudqqhlstsi7uge4lir7ff3ty
       '@mui/material': 5.10.9_ikcgkdnp4bn3rgptamntbhbo7e
       clsx: 1.2.1
       hoist-non-react-statics: 3.3.2
@@ -15423,13 +15361,19 @@ packages:
     peerDependencies:
       react-scripts: '>=2.1.3'
     dependencies:
-      react-scripts: 5.0.1_yj7xztyo4flup4zk6yj3sg7fka
+      react-scripts: 5.0.1_n7mqr4n4gswjc26jfdbklgbjf4
       semver: 5.7.1
     dev: false
 
   /react-dev-utils/12.0.1_bc3cndyb4zfm7v6hebu43p6ee4:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.1
@@ -15455,12 +15399,12 @@ packages:
       shell-quote: 1.7.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      typescript: 4.7.4
+      webpack: 5.74.0
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-devtools-core/4.24.0:
@@ -15543,7 +15487,7 @@ packages:
   /react-native-gradle-plugin/0.70.3:
     resolution: {integrity: sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==}
 
-  /react-native/0.70.3_l7pre6hb4rf5lokhq3umcfwfl4:
+  /react-native/0.70.3_sxyvc5w76clw6xultp2jaqrfwi:
     resolution: {integrity: sha512-EiJxOonyvpSWa3Eik7a6YAD6QU8lK2W9M/DDdYlpWmIlGLCd5110rIpEZjxttsyrohxlRJAYRgJ9Tx2mMXqtfw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -15551,7 +15495,7 @@ packages:
       react: 18.1.0
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@react-native-community/cli': 9.1.3
+      '@react-native-community/cli': 9.1.3_@babel+core@7.19.3
       '@react-native-community/cli-platform-android': 9.1.0
       '@react-native-community/cli-platform-ios': 9.1.2
       '@react-native/assets': 1.0.0
@@ -15564,7 +15508,7 @@ packages:
       invariant: 2.2.4
       jsc-android: 250230.2.1
       memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.72.3
+      metro-react-native-babel-transformer: 0.72.3_@babel+core@7.19.3
       metro-runtime: 0.72.3
       metro-source-map: 0.72.3
       mkdirp: 0.5.6
@@ -15584,6 +15528,7 @@ packages:
       whatwg-fetch: 3.6.2
       ws: 6.2.2
     transitivePeerDependencies:
+      - '@babel/core'
       - '@babel/preset-env'
       - bufferutil
       - encoding
@@ -15617,11 +15562,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-scripts/5.0.1_yj7xztyo4flup4zk6yj3sg7fka:
+  /react-scripts/5.0.1_n7mqr4n4gswjc26jfdbklgbjf4:
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:
+      eslint: '*'
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -15670,7 +15616,7 @@ packages:
       semver: 7.3.8
       source-map-loader: 3.0.1_webpack@5.74.0
       style-loader: 3.3.1_webpack@5.74.0
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
       terser-webpack-plugin: 5.3.6_webpack@5.74.0
       typescript: 4.7.4
       webpack: 5.74.0
@@ -16204,7 +16150,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: false
 
@@ -16853,7 +16799,7 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /styled-jsx/5.0.2_react@18.2.0:
+  /styled-jsx/5.0.2_b6k74wvxdvqypha4emuv7fd2ke:
     resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -16866,6 +16812,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
+      '@babel/core': 7.19.3
       react: 18.2.0
     dev: false
 
@@ -16975,10 +16922,12 @@ packages:
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.18:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3


### PR DESCRIPTION
#### Problem statement

There is no way to interrogate the device, from JavaScript, to know whether it will respond to the protocol `solana-wallet://` or not. You have to try it, and presume that it doesn't unless the browser backgrounds.

If the browser hasn't backgrounded within a reasonable amount of time, then we assume there are no wallets installed. At this point we want to show the wallet ecosystem page so that the user can choose a wallet to install.

#### Summary of changes

* If the protocol throws `ERROR_WALLET_NOT_FOUND` then redirect the webpage to the URL set in the `SolanaMobileWalletAdapter`.

#### Test plan
https://user-images.githubusercontent.com/13243/195958935-e75ccae8-a198-44af-8237-60acadbd3ae3.mp4

#### Notes

This is implemented as a navigation to `adapter.url` and not a popup window. This is because browsers will block any popup window that isn't directly connected to a user-initiated gesture like a tap. Between the time the user taps the connect button and the time that the wallet adapter throws `ERROR_WALLET_NOT_FOUND`, that chain has been broken long enough for the browser's popup blocker to engage.