### PR TITLE
Rename wallets prop to make it clear it's only for legacy adapters now

### DIFF
--- a/APP.md
+++ b/APP.md
@@ -49,12 +49,16 @@ export const Wallet: FC = () => {
     const wallets = useMemo(
         () => [
             /**
-             * Select the wallets you wish to support, by instantiating wallet adapters here.
+             * Wallets that implement either of these standards will be available automatically.
              *
-             * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
-             * That package supports tree shaking and lazy loading -- only the wallets you import
-             * will be compiled into your application, and only the dependencies of wallets that
-             * your users connect to will be loaded.
+             *   - Solana Mobile Stack Mobile Wallet Adatper Protocol
+             *     (https://github.com/solana-mobile/mobile-wallet-adapter)
+             *   - Wallet Standard
+             *     (https://github.com/wallet-standard/wallet-standard)
+             *
+             * If you wish to support a wallet that supports none of thost standards, instantiate
+             * its legacy wallet adapter here. Common legacy adapters can be found in the npm
+             * package `@solana/wallet-adapter-wallets`.
              */
             new UnsafeBurnerWalletAdapter(),
         ],

--- a/packages/starter/create-react-app-starter/src/App.tsx
+++ b/packages/starter/create-react-app-starter/src/App.tsx
@@ -27,12 +27,16 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
     const wallets = useMemo(
         () => [
             /**
-             * Select the wallets you wish to support, by instantiating wallet adapters here.
+             * Wallets that implement either of these standards will be available automatically.
              *
-             * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
-             * That package supports tree shaking and lazy loading -- only the wallets you import
-             * will be compiled into your application, and only the dependencies of wallets that
-             * your users connect to will be loaded.
+             *   - Solana Mobile Stack Mobile Wallet Adatper Protocol
+             *     (https://github.com/solana-mobile/mobile-wallet-adapter)
+             *   - Wallet Standard
+             *     (https://github.com/wallet-standard/wallet-standard)
+             *
+             * If you wish to support a wallet that supports none of thost standards, instantiate
+             * its legacy wallet adapter here. Common legacy adapters can be found in the npm
+             * package `@solana/wallet-adapter-wallets`.
              */
             new UnsafeBurnerWalletAdapter(),
         ],

--- a/packages/starter/example/src/components/ContextProvider.tsx
+++ b/packages/starter/example/src/components/ContextProvider.tsx
@@ -60,12 +60,16 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const wallets = useMemo(
         () => [
             /**
-             * Select the wallets you wish to support, by instantiating wallet adapters here.
+             * Wallets that implement either of these standards will be available automatically.
              *
-             * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
-             * That package supports tree shaking and lazy loading -- only the wallets you import
-             * will be compiled into your application, and only the dependencies of wallets that
-             * your users connect to will be loaded.
+             *   - Solana Mobile Stack Mobile Wallet Adatper Protocol
+             *     (https://github.com/solana-mobile/mobile-wallet-adapter)
+             *   - Wallet Standard
+             *     (https://github.com/wallet-standard/wallet-standard)
+             *
+             * If you wish to support a wallet that supports none of thost standards, instantiate
+             * its legacy wallet adapter here. Common legacy adapters can be found in the npm
+             * package `@solana/wallet-adapter-wallets`.
              */
             new UnsafeBurnerWalletAdapter(),
         ],

--- a/packages/starter/material-ui-starter/src/App.tsx
+++ b/packages/starter/material-ui-starter/src/App.tsx
@@ -29,12 +29,16 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
     const wallets = useMemo(
         () => [
             /**
-             * Select the wallets you wish to support, by instantiating wallet adapters here.
+             * Wallets that implement either of these standards will be available automatically.
              *
-             * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
-             * That package supports tree shaking and lazy loading -- only the wallets you import
-             * will be compiled into your application, and only the dependencies of wallets that
-             * your users connect to will be loaded.
+             *   - Solana Mobile Stack Mobile Wallet Adatper Protocol
+             *     (https://github.com/solana-mobile/mobile-wallet-adapter)
+             *   - Wallet Standard
+             *     (https://github.com/wallet-standard/wallet-standard)
+             *
+             * If you wish to support a wallet that supports none of thost standards, instantiate
+             * its legacy wallet adapter here. Common legacy adapters can be found in the npm
+             * package `@solana/wallet-adapter-wallets`.
              */
             new UnsafeBurnerWalletAdapter(),
         ],

--- a/packages/starter/nextjs-starter/src/pages/_app.tsx
+++ b/packages/starter/nextjs-starter/src/pages/_app.tsx
@@ -21,12 +21,16 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
     const wallets = useMemo(
         () => [
             /**
-             * Select the wallets you wish to support, by instantiating wallet adapters here.
+             * Wallets that implement either of these standards will be available automatically.
              *
-             * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
-             * That package supports tree shaking and lazy loading -- only the wallets you import
-             * will be compiled into your application, and only the dependencies of wallets that
-             * your users connect to will be loaded.
+             *   - Solana Mobile Stack Mobile Wallet Adatper Protocol
+             *     (https://github.com/solana-mobile/mobile-wallet-adapter)
+             *   - Wallet Standard
+             *     (https://github.com/wallet-standard/wallet-standard)
+             *
+             * If you wish to support a wallet that supports none of thost standards, instantiate
+             * its legacy wallet adapter here. Common legacy adapters can be found in the npm
+             * package `@solana/wallet-adapter-wallets`.
              */
             new UnsafeBurnerWalletAdapter(),
         ],

--- a/packages/starter/react-ui-starter/src/App.tsx
+++ b/packages/starter/react-ui-starter/src/App.tsx
@@ -24,12 +24,16 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
     const wallets = useMemo(
         () => [
             /**
-             * Select the wallets you wish to support, by instantiating wallet adapters here.
+             * Wallets that implement either of these standards will be available automatically.
              *
-             * Common adapters can be found in the npm package `@solana/wallet-adapter-wallets`.
-             * That package supports tree shaking and lazy loading -- only the wallets you import
-             * will be compiled into your application, and only the dependencies of wallets that
-             * your users connect to will be loaded.
+             *   - Solana Mobile Stack Mobile Wallet Adatper Protocol
+             *     (https://github.com/solana-mobile/mobile-wallet-adapter)
+             *   - Wallet Standard
+             *     (https://github.com/wallet-standard/wallet-standard)
+             *
+             * If you wish to support a wallet that supports none of thost standards, instantiate
+             * its legacy wallet adapter here. Common legacy adapters can be found in the npm
+             * package `@solana/wallet-adapter-wallets`.
              */
             new UnsafeBurnerWalletAdapter(),
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
       '@solana/wallet-adapter-base': ^0.9.18
       '@solana/wallet-adapter-react': ^0.15.21-rc.0
       '@solana/wallet-adapter-react-ui': ^0.9.19-rc.0
-      '@solana/wallet-adapter-wallets': ^0.19.1
+      '@solana/wallet-adapter-wallets': ^0.19.2
       '@solana/web3.js': ^1.61.0
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/react': ^13.3.0
@@ -148,12 +148,12 @@ importers:
       '@emotion/styled': ^11.10.0
       '@mui/icons-material': ^5.8.4
       '@mui/material': ^5.9.3
-      '@solana/wallet-adapter-ant-design': ^0.11.15
+      '@solana/wallet-adapter-ant-design': ^0.11.16-rc.0
       '@solana/wallet-adapter-base': ^0.9.18
-      '@solana/wallet-adapter-material-ui': ^0.16.16
+      '@solana/wallet-adapter-material-ui': ^0.16.17-rc.0
       '@solana/wallet-adapter-react': ^0.15.21-rc.0
       '@solana/wallet-adapter-react-ui': ^0.9.19-rc.0
-      '@solana/wallet-adapter-wallets': ^0.19.1
+      '@solana/wallet-adapter-wallets': ^0.19.2
       '@solana/web3.js': ^1.61.0
       '@types/bs58': ^4.0.1
       '@types/node-fetch': ^2.6.2
@@ -213,9 +213,9 @@ importers:
       '@mui/icons-material': ^5.8.4
       '@mui/material': ^5.9.3
       '@solana/wallet-adapter-base': ^0.9.18
-      '@solana/wallet-adapter-material-ui': ^0.16.16
+      '@solana/wallet-adapter-material-ui': ^0.16.17-rc.0
       '@solana/wallet-adapter-react': ^0.15.21-rc.0
-      '@solana/wallet-adapter-wallets': ^0.19.1
+      '@solana/wallet-adapter-wallets': ^0.19.2
       '@solana/web3.js': ^1.61.0
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
@@ -254,7 +254,7 @@ importers:
       '@solana/wallet-adapter-base': ^0.9.18
       '@solana/wallet-adapter-react': ^0.15.21-rc.0
       '@solana/wallet-adapter-react-ui': ^0.9.19-rc.0
-      '@solana/wallet-adapter-wallets': ^0.19.1
+      '@solana/wallet-adapter-wallets': ^0.19.2
       '@types/node-fetch': ^2.6.2
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
@@ -289,7 +289,7 @@ importers:
       '@solana/wallet-adapter-base': ^0.9.18
       '@solana/wallet-adapter-react': ^0.15.21-rc.0
       '@solana/wallet-adapter-react-ui': ^0.9.19-rc.0
-      '@solana/wallet-adapter-wallets': ^0.19.1
+      '@solana/wallet-adapter-wallets': ^0.19.2
       '@solana/web3.js': ^1.61.0
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0


### PR DESCRIPTION
Now that the era of the Wallet Standard and Mobile Wallet Adapter is upon us, it might be time to make it clear that this configuration prop is _only_ for use when developers want to support a legacy adapter.

The first commit updates the code comments. The second renames the prop, makes it optional, and deprecates the old one.