### PR TITLE
Restore ‘unset when fails to connect’ behavior

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -9,7 +9,7 @@ import type { Adapter, WalletError, WalletName } from '@solana/wallet-adapter-ba
 import { useStandardWalletAdapters } from '@solana/wallet-standard-wallet-adapter-react';
 import type { Cluster } from '@solana/web3.js';
 import type { ReactNode } from 'react';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import getClusterFromConnection from './getClusterFromConnection.js';
 import getEnvironment, { Environment } from './getEnvironment.js';
 import { useConnection } from './useConnection.js';
@@ -157,6 +157,12 @@ export function WalletProvider({
             window.removeEventListener('beforeunload', handleBeforeUnload);
         };
     }, [adaptersWithStandardAdapters, walletName]);
+    const handleConnectError = useCallback(() => {
+        if (adapter && adapter.name !== SolanaMobileWalletAdapterWalletName) {
+            // If any error happens while connecting, unset the adapter.
+            setWalletName(null);
+        }
+    }, [adapter]);
     return (
         <WalletProviderBase
             {...props}
@@ -164,6 +170,7 @@ export function WalletProvider({
             isUnloadingRef={isUnloading}
             key={adapter?.name}
             onAutoConnectRequest={handleAutoConnectRequest}
+            onConnectError={handleConnectError}
             onSelectWallet={setWalletName}
             wallets={adaptersWithMobileWalletAdapter}
         />

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -19,6 +19,7 @@ type Props = Readonly<
         isUnloadingRef: React.RefObject<boolean>;
         // NOTE: The presence/absence of this handler implies that auto-connect is enabled/disabled.
         onAutoConnectRequest?: () => Promise<void>;
+        onConnectError: () => void;
         onSelectWallet: (walletName: WalletName) => void;
     }
 >;
@@ -28,6 +29,7 @@ export function WalletProviderBase({
     children,
     isUnloadingRef,
     onAutoConnectRequest,
+    onConnectError,
     onError,
     onSelectWallet,
     wallets: adapters,
@@ -156,6 +158,7 @@ export function WalletProviderBase({
             try {
                 await onAutoConnectRequest();
             } catch {
+                onConnectError();
                 // Drop the error. It will be caught by `handleError` anyway.
             } finally {
                 setConnecting(false);
@@ -224,6 +227,9 @@ export function WalletProviderBase({
         setConnecting(true);
         try {
             await adapter.connect();
+        } catch (e) {
+            onConnectError();
+            throw e;
         } finally {
             setConnecting(false);
             isConnecting.current = false;

--- a/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
@@ -54,6 +54,7 @@ describe('WalletProviderBase', () => {
             root.render(
                 <WalletProviderBase
                     {...props}
+                    onConnectError={jest.fn()}
                     onSelectWallet={jest.fn()}
                     isUnloadingRef={isUnloading}
                     wallets={adapters}


### PR DESCRIPTION
@jordansexton pointed out the case where:

* You're using `MultiConnectButton`
* You start a connection attempt
* The user denies it

Now you're in a situation where you _can't_ deselect the wallet because of the structure of `MultiConnectButton`. There's no UI to do so.

This PR restores the ‘unset the wallet when encountering an error’ paradigm, but only does so if the error encountered is:

* not with `SolanaMobileWalletAdapter`
* a `WalletConnectionError`

#### Test plan

https://user-images.githubusercontent.com/13243/196283272-1cb8d76e-cb29-4e5b-81d4-8b5d90f08ce9.mov