### PR TITLE
Narrowly specify cluster inferring function

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -7,10 +7,9 @@ import {
 } from '@solana-mobile/wallet-adapter-mobile';
 import type { Adapter, WalletError, WalletName } from '@solana/wallet-adapter-base';
 import { useStandardWalletAdapters } from '@solana/wallet-standard-wallet-adapter-react';
-import type { Cluster } from '@solana/web3.js';
 import type { ReactNode } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import getClusterFromConnection from './getClusterFromConnection.js';
+import getInferredClusterFromEndpoint from './getInferredClusterFromEndpoint.js';
 import getEnvironment, { Environment } from './getEnvironment.js';
 import { useConnection } from './useConnection.js';
 import { useLocalStorage } from './useLocalStorage.js';
@@ -69,10 +68,10 @@ export function WalletProvider({
                 uri: getUriForAppIdentity(),
             },
             authorizationResultCache: createDefaultAuthorizationResultCache(),
-            cluster: getClusterFromConnection(connection),
+            cluster: getInferredClusterFromEndpoint(connection?.rpcEndpoint),
             onWalletNotFound: createDefaultWalletNotFoundHandler(),
         });
-    }, [adaptersWithStandardAdapters, connection]);
+    }, [adaptersWithStandardAdapters, connection?.rpcEndpoint]);
     const adaptersWithMobileWalletAdapter = useMemo(() => {
         if (mobileWalletAdapter == null || adaptersWithStandardAdapters.indexOf(mobileWalletAdapter) !== -1) {
             return adaptersWithStandardAdapters;

--- a/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
@@ -27,11 +27,11 @@ jest.mock('../getEnvironment.js', () => ({
     __esModule: true,
     default: () => jest.requireActual('../getEnvironment.js').Environment.MOBILE_WEB,
 }));
-jest.mock('../getClusterFromConnection.js', () => ({
-    ...jest.requireActual('../getClusterFromConnection.js'),
+jest.mock('../getInferredClusterFromEndpoint.js', () => ({
+    ...jest.requireActual('../getInferredClusterFromEndpoint.js'),
     __esModule: true,
-    default: (connection?: Connection) => {
-        switch (connection?.rpcEndpoint) {
+    default: (endpoint?: string) => {
+        switch (endpoint) {
             case 'https://fake-endpoint-for-test.com':
                 return 'fake-cluster-for-test';
             default:

--- a/packages/core/react/src/__tests__/getClusterFromConnection-test.ts
+++ b/packages/core/react/src/__tests__/getClusterFromConnection-test.ts
@@ -1,29 +1,34 @@
-import { Connection } from '@solana/web3.js';
-import getClusterFromConnection from '../getClusterFromConnection.js';
+import getInferredClusterFromEndpoint from '../getInferredClusterFromEndpoint.js';
 
-describe('getClusterFromConnection()', () => {
-    describe('when the connection is `undefined`', () => {
-        const connection = undefined;
+describe('getInferredClusterFromEndpoint()', () => {
+    describe('when the endpoint is `undefined`', () => {
+        const endpoint = undefined;
         it('creates a new mobile wallet adapter with `mainnet-beta` as the cluster', () => {
-            expect(getClusterFromConnection(connection)).toBe('mainnet-beta');
+            expect(getInferredClusterFromEndpoint(endpoint)).toBe('mainnet-beta');
+        });
+    });
+    describe('when the endpoint is the empty string', () => {
+        const endpoint = '';
+        it('creates a new mobile wallet adapter with `mainnet-beta` as the cluster', () => {
+            expect(getInferredClusterFromEndpoint(endpoint)).toBe('mainnet-beta');
         });
     });
     describe("when the endpoint contains the word 'devnet'", () => {
-        const connection = new Connection('https://foo-devnet.com');
+        const endpoint = 'https://foo-devnet.com';
         it('creates a new mobile wallet adapter with `devnet` as the cluster', () => {
-            expect(getClusterFromConnection(connection)).toBe('devnet');
+            expect(getInferredClusterFromEndpoint(endpoint)).toBe('devnet');
         });
     });
     describe("when the endpoint contains the word 'testnet'", () => {
-        const connection = new Connection('https://foo-testnet.com');
+        const endpoint = 'https://foo-testnet.com';
         it('creates a new mobile wallet adapter with `testnet` as the cluster', () => {
-            expect(getClusterFromConnection(connection)).toBe('testnet');
+            expect(getInferredClusterFromEndpoint(endpoint)).toBe('testnet');
         });
     });
     describe("when the endpoint contains the word 'mainnet-beta'", () => {
-        const connection = new Connection('https://foo-mainnet-beta.com');
+        const endpoint = 'https://foo-mainnet-beta.com';
         it('creates a new mobile wallet adapter with `mainnet-beta` as the cluster', () => {
-            expect(getClusterFromConnection(connection)).toBe('mainnet-beta');
+            expect(getInferredClusterFromEndpoint(endpoint)).toBe('mainnet-beta');
         });
     });
 });

--- a/packages/core/react/src/getClusterFromConnection.ts
+++ b/packages/core/react/src/getClusterFromConnection.ts
@@ -1,8 +1,0 @@
-import type { Connection, Cluster } from '@solana/web3.js';
-
-export default function getClusterFromConnection(connection?: Connection): Cluster {
-    if (!connection) return 'mainnet-beta';
-    if (/devnet/i.test(connection.rpcEndpoint)) return 'devnet';
-    if (/testnet/i.test(connection.rpcEndpoint)) return 'testnet';
-    return 'mainnet-beta';
-}

--- a/packages/core/react/src/getInferredClusterFromEndpoint.ts
+++ b/packages/core/react/src/getInferredClusterFromEndpoint.ts
@@ -1,0 +1,14 @@
+import type { Cluster } from '@solana/web3.js';
+
+export default function getInferredClusterFromEndpoint(endpoint?: string): Cluster {
+    if (!endpoint) {
+        return 'mainnet-beta';
+    }
+    if (/devnet/i.test(endpoint)) {
+        return 'devnet';
+    } else if (/testnet/i.test(endpoint)) {
+        return 'testnet';
+    } else {
+        return 'mainnet-beta';
+    }
+}


### PR DESCRIPTION
I noticed that an app recycled its `Connection` over and over, even though the `rpcEndpoint` didn't change. This had the side effect of breaking memoization in `WalletProvider`, causing the MWA to get created over and over.

In this PR we make all of this code depend only on the value of the endpoint string.