### PR TITLE
Add Infinity Wallet

### DIFF
--- a/packages/wallets/infinityWallet/LICENSE
+++ b/packages/wallets/infinityWallet/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/wallets/infinityWallet/README.md
+++ b/packages/wallets/infinityWallet/README.md
@@ -1,0 +1,5 @@
+# `@solana/wallet-adapter-infinitywallet`
+
+<!-- @TODO -->
+
+Coming soon.

--- a/packages/wallets/infinityWallet/package.json
+++ b/packages/wallets/infinityWallet/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "@solana/wallet-adapter-infinitywallet",
+    "version": "0.1.0",
+    "author": "Solana Maintainers <maintainers@solana.foundation>",
+    "repository": "https://github.com/solana-labs/wallet-adapter",
+    "license": "Apache-2.0",
+    "type": "module",
+    "sideEffects": false,
+    "main": "./lib/cjs/index.js",
+    "module": "./lib/esm/index.js",
+    "types": "./lib/types/index.d.ts",
+    "engines": {
+        "node": ">=16"
+    },
+    "exports": {
+        "require": "./lib/cjs/index.js",
+        "import": "./lib/esm/index.js",
+        "types": "./lib/types/index.d.ts"
+    },
+    "files": [
+        "lib",
+        "src",
+        "LICENSE"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "clean": "shx mkdir -p lib && shx rm -rf lib",
+        "package": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
+    },
+    "peerDependencies": {
+        "@solana/web3.js": "^1.50.1"
+    },
+    "dependencies": {
+        "@solana/wallet-adapter-base": "workspace:^"
+    },
+    "devDependencies": {
+        "@solana/web3.js": "^1.50.1",
+        "shx": "^0.3.4"
+    }
+}

--- a/packages/wallets/infinityWallet/src/adapter.ts
+++ b/packages/wallets/infinityWallet/src/adapter.ts
@@ -1,0 +1,232 @@
+import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import {
+    BaseSignerWalletAdapter,
+    scopePollingDetectionStrategy,
+    WalletAccountError,
+    WalletConnectionError,
+    WalletDisconnectedError,
+    WalletDisconnectionError,
+    WalletError,
+    WalletNotConnectedError,
+    WalletNotReadyError,
+    WalletPublicKeyError,
+    WalletReadyState,
+    WalletSendTransactionError,
+    WalletSignMessageError,
+    WalletSignTransactionError,
+} from '@solana/wallet-adapter-base';
+import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
+
+interface InfinityWalletWalletEvents {
+    connect(...args: unknown[]): unknown;
+    disconnect(...args: unknown[]): unknown;
+}
+interface InfinityWallet extends EventEmitter<InfinityWalletWalletEvents> {
+    isInfinityWallet?: boolean;
+    connect(): Promise<void>;
+    disconnect(): Promise<void>;
+    getAccount(): Promise<string>;
+    signTransaction(transaction: Transaction): Promise<Transaction>;
+    signAllTransactions(transactions: Transaction[]): Promise<Transaction[]>;
+    signAndSendTransaction(
+        transaction: Transaction,
+        options?: SendOptions
+    ): Promise<{ signature: TransactionSignature }>;
+    signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>;
+}
+
+interface InfinityWalletWindow extends Window {
+    infinitywallet?: {
+          solana?: InfinityWallet;
+    };
+    solana?: InfinityWallet;
+}
+
+declare const window: InfinityWalletWindow;
+
+export interface InfinityWalletAdapterConfig {}
+
+export const InfinityWalletName = 'InfinityWallet' as WalletName<'InfinityWallet'>;
+
+export class InfinityWalletAdapter extends BaseSignerWalletAdapter {
+    name = InfinityWalletName;
+    _url = 'https://infinitywallet.io/download';
+    icon =
+        'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMi4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9IjAgMCAxMDI1IDEwMjUiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEwMjUgMTAyNTsiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4NCgkuc3Qwe2ZpbGw6dXJsKCNTVkdJRF8xXyk7fQ0KCS5zdDF7ZmlsbDp1cmwoI1NWR0lEXzJfKTt9DQoJLnN0MntvcGFjaXR5OjAuNDk7ZmlsbDp1cmwoI1NWR0lEXzNfKTtlbmFibGUtYmFja2dyb3VuZDpuZXcgICAgO30NCgkuc3Qze29wYWNpdHk6MC40OTtmaWxsOnVybCgjU1ZHSURfNF8pO2VuYWJsZS1iYWNrZ3JvdW5kOm5ldyAgICA7fQ0KCS5zdDR7b3BhY2l0eTowLjQ5O2ZpbGw6dXJsKCNTVkdJRF81Xyk7ZW5hYmxlLWJhY2tncm91bmQ6bmV3ICAgIDt9DQoJLnN0NXtmaWxsOnVybCgjU1ZHSURfNl8pO30NCgkuc3Q2e29wYWNpdHk6MC40OTtmaWxsOnVybCgjU1ZHSURfN18pO2VuYWJsZS1iYWNrZ3JvdW5kOm5ldyAgICA7fQ0KCS5zdDd7b3BhY2l0eTowLjQ5O2ZpbGw6dXJsKCNTVkdJRF84Xyk7ZW5hYmxlLWJhY2tncm91bmQ6bmV3ICAgIDt9DQoJLnN0OHtvcGFjaXR5OjAuNDk7ZmlsbDp1cmwoI1NWR0lEXzlfKTtlbmFibGUtYmFja2dyb3VuZDpuZXcgICAgO30NCjwvc3R5bGU+DQo8bGluZWFyR3JhZGllbnQgaWQ9IlNWR0lEXzFfIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjUxMi41IiB5MT0iMjAzLjgxNTIiIHgyPSI1MTIuNSIgeTI9Ijk0Mi45NzAxIj4NCgk8c3RvcCAgb2Zmc2V0PSIwIiBzdHlsZT0ic3RvcC1jb2xvcjojMUQyNjQzIi8+DQoJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzEyMTQyQyIvPg0KPC9saW5lYXJHcmFkaWVudD4NCjxyZWN0IGNsYXNzPSJzdDAiIHdpZHRoPSIxMDI1IiBoZWlnaHQ9IjEwMjUiLz4NCjxnPg0KCTxnPg0KCQkNCgkJCTxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMl8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iMzE0LjM0OTciIHkxPSIxMDg4LjUyMjIiIHgyPSIzMTQuMzQ5NyIgeTI9IjM2LjIyNTIiIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoMSAwIDAgLTEgMCAxMjYwKSI+DQoJCQk8c3RvcCAgb2Zmc2V0PSI1LjEwMjA0NGUtMDMiIHN0eWxlPSJzdG9wLWNvbG9yOiMwMEJGRTEiLz4NCgkJCTxzdG9wICBvZmZzZXQ9IjAuOTY1MSIgc3R5bGU9InN0b3AtY29sb3I6IzI3MzhBQiIvPg0KCQk8L2xpbmVhckdyYWRpZW50Pg0KCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNTU0LjgsMzcxLjZjLTEuMS0zLTMuNi0zLjktNC43LTQuMmMtMS4xLTAuMy00LjItMC44LTYuOCwxLjhMNTI5LDM4My41bC0yLjQsMi40TDQxMywyNzIuOQ0KCQkJYy0yMC43LTIwLjctNDguNC0zMi4xLTc3LjgtMzIuMXMtNTcsMTEuNC03Ny43LDMyLjFMOTUuOCw0MzQuOGMtMjAuOCwyMC44LTMyLjIsNDguNi0zMi4xLDc4QzYzLjYsNTQyLjQsNzUsNTcwLjIsOTUuOCw1OTENCgkJCWwxNjEuOSwxNjFjMjAuNywyMC43LDQ4LjMsMzIuMSw3Ny43LDMyLjFjMjkuNCwwLDU3LTExLjQsNzcuNy0zMi4xYzAsMCwzNi41LTM2LjUsMzYuOC0zNi44YzQuOC00LjgsMTAuNi0xMS40LDEzLjgtMjANCgkJCWMyLjUtNi45LDMuMy0xNC40LDIuMy0yMS42Yy0xLTcuMy0zLjctMTQuMy03LjktMjAuMmMtMS42LTIuMy0zLjQtNC41LTUuNS02LjRjLTE3LjktMTcuNi00Ny0xNy41LTY0LjksMC4zTDM0Ny45LDY4Nw0KCQkJYy0yLjQsMi40LTUuNCw0LjEtOC43LDQuOGMtMy44LDAuOC02LjIsMC41LTkuNC0wLjZjLTMuMi0xLjEtNS45LTMtOC4yLTUuM0wxNjAuOSw1MjVjLTIuNS0yLjUtNC4yLTUuNy00LjktOQ0KCQkJYy0wLjktNC40LDAtOSwyLjItMTIuNmwwLjktMWMxLjktMS45LDE2Mi4zLTE2MiwxNjMuNy0xNjMuNGMyLjYtMi42LDUuNy00LjIsOS4zLTQuOWMxLjEtMC4yLDIuMi0wLjMsMy4zLTAuMw0KCQkJYzQuOCwwLDkuMiwxLjgsMTIuNSw1LjNsMTEzLjIsMTEyLjVsLTUuNyw1LjdsLTExLjEsMTEuM2MtMi42LDIuNi0yLjEsNS43LTEuOCw2LjhjMC4zLDEuMSwxLjIsMy42LDQuMiw0LjdMNTQ5LDQ5Mi42DQoJCQljNC4yLTAuMSw4LjItMS43LDExLjItNC43YzMuMS0zLDQuNy03LjEsNC44LTExLjNMNTU0LjgsMzcxLjZ6Ii8+DQoJCQ0KCQkJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF8zXyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSIxMTIuODQ5NyIgeTE9IjcxOS40NTQyIiB4Mj0iMTgwLjY0MjMiIHkyPSI2NjIuNzU0NyIgZ3JhZGllbnRUcmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAtMSAtMC45MzcxIDEyNTkuMzkpIj4NCgkJCTxzdG9wICBvZmZzZXQ9IjMuNDg4NTc1ZS0wMiIgc3R5bGU9InN0b3AtY29sb3I6IzFCMTQ2NCIvPg0KCQkJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzFCMTQ2NDtzdG9wLW9wYWNpdHk6MCIvPg0KCQk8L2xpbmVhckdyYWRpZW50Pg0KCQk8cGF0aCBjbGFzcz0ic3QyIiBkPSJNMTU5LjYsNTIzLjZjLTQuNi01LjItNS41LTE0LjItMS40LTIwLjNjMCwwLTUzLjIsNTguMS0yNy42LDEyMi4zbDMzLjcsMzMuNWw0OS04MS41TDE1OS42LDUyMy42eiIvPg0KCQkNCgkJCTxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfNF8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iMjMwNi4wOTk2IiB5MT0iLTQwMC43MzIyIiB4Mj0iMjI3My44MDYyIiB5Mj0iLTQ0Ni41MzAzIiBncmFkaWVudFRyYW5zZm9ybT0ibWF0cml4KC0xIDAgMCAxIDI2ODEuMDAxNSAxMTIyLjA5MykiPg0KCQkJPHN0b3AgIG9mZnNldD0iMy40ODg1NzVlLTAyIiBzdHlsZT0ic3RvcC1jb2xvcjojMUIxNDY0Ii8+DQoJCQk8c3RvcCAgb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojMUIxNDY0O3N0b3Atb3BhY2l0eTowIi8+DQoJCTwvbGluZWFyR3JhZGllbnQ+DQoJCTxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0zMjUuNCw2ODkuMWM2MCw1NS4yLDEyNi4xLDI0LjUsMTI2LjEsMjQuNXM4LjctOCwxMi4yLTE4LjZjLTguOS00LjMtNzMuNC01MC41LTczLjQtNTAuNWwtMzguMSwzOC4xDQoJCQlDMzM4LjUsNjk5LjIsMzI1LjQsNjg5LjEsMzI1LjQsNjg5LjF6Ii8+DQoJCQ0KCQkJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF81XyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSIyMzk3LjEwNjIiIHkxPSItODIwLjk3MzYiIHgyPSIyNDIxLjM0MjMiIHkyPSItNzYxLjAyMTIiIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoLTEgMCAwIDEgMjY4MS4wMDE1IDExMjIuMDkzKSI+DQoJCQk8c3RvcCAgb2Zmc2V0PSIzLjQ4ODU3NWUtMDIiIHN0eWxlPSJzdG9wLWNvbG9yOiMxQjE0NjQiLz4NCgkJCTxzdG9wICBvZmZzZXQ9IjEiIHN0eWxlPSJzdG9wLWNvbG9yOiMxQjE0NjQ7c3RvcC1vcGFjaXR5OjAiLz4NCgkJPC9saW5lYXJHcmFkaWVudD4NCgkJPHBhdGggY2xhc3M9InN0NCIgZD0iTTI4NS44LDM3Ni4xYzAsMCwzOC40LTM4LjcsMzguNS0zOC41YzAsMCwxMC4zLTguMiwyMS4xLTAuN2MwLDAtNjMuOS01Mi42LTEzMi4yLTE5LjZsLTE5LjksMjBMMjg1LjgsMzc2LjF6DQoJCQkiLz4NCgk8L2c+DQoJPGc+DQoJCQ0KCQkJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF82XyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSI3MTMuMTUwMyIgeTE9IjEwODguNTIyMiIgeDI9IjcxMy4xNTAzIiB5Mj0iMzYuMjI1MiIgZ3JhZGllbnRUcmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAtMSAwIDEyNjApIj4NCgkJCTxzdG9wICBvZmZzZXQ9IjUuMTAyMDQ0ZS0wMyIgc3R5bGU9InN0b3AtY29sb3I6IzAwQkZFMSIvPg0KCQkJPHN0b3AgIG9mZnNldD0iMC45NjUxIiBzdHlsZT0ic3RvcC1jb2xvcjojMjczOEFCIi8+DQoJCTwvbGluZWFyR3JhZGllbnQ+DQoJCTxwYXRoIGNsYXNzPSJzdDUiIGQ9Ik00NzIuNyw2NTMuNGMxLjEsMywzLjYsMy45LDQuNyw0LjJzNC4yLDAuOCw2LjgtMS44bDE0LjMtMTQuM2wyLjQtMi40TDYxNC41LDc1Mg0KCQkJYzIwLjcsMjAuNyw0OC40LDMyLjEsNzcuOCwzMi4xYzI5LjQsMCw1Ny0xMS40LDc3LjctMzIuMWwxNjEuNy0xNjEuOWMyMC44LTIwLjgsMzIuMi00OC42LDMyLjEtNzhjMC4xLTI5LjYtMTEuMy01Ny40LTMyLjEtNzguMg0KCQkJbC0xNjEuOS0xNjFjLTIwLjctMjAuNy00OC4zLTMyLjEtNzcuNy0zMi4xcy01NywxMS40LTc3LjcsMzIuMWMwLDAtMzYuNSwzNi41LTM2LjgsMzYuOGMtNC44LDQuOC0xMC42LDExLjQtMTMuOCwyMA0KCQkJYy0yLjUsNi45LTMuMywxNC40LTIuMywyMS42YzEsNy4zLDMuNywxNC4zLDcuOSwyMC4yYzEuNiwyLjMsMy40LDQuNSw1LjUsNi40YzE3LjksMTcuNiw0NywxNy41LDY0LjktMC4zbDM5LjgtMzkuNw0KCQkJYzIuNC0yLjQsNS40LTQuMSw4LjctNC44YzMuOC0wLjgsNi4yLTAuNSw5LjQsMC42czUuOSwzLDguMiw1LjNsMTYwLjcsMTYwLjdjMi41LDIuNSw0LjIsNS43LDQuOSw5YzAuOSw0LjQsMCw5LTIuMiwxMi42bC0wLjksMQ0KCQkJYy0xLjksMS45LTE2Mi4zLDE2Mi0xNjMuNywxNjMuNGMtMi42LDIuNi01LjcsNC4yLTkuMyw0LjljLTEuMSwwLjItMi4yLDAuMy0zLjMsMC4zYy00LjgsMC05LjItMS44LTEyLjUtNS4zbC0xMTMuMy0xMTJsNS43LTUuNw0KCQkJbDExLjEtMTEuM2MyLjYtMi42LDIuMS01LjcsMS44LTYuOHMtMS4yLTMuNi00LjItNC43bC0xMDIuMi0xMi41Yy00LjIsMC4xLTguMiwxLjctMTEuMiw0LjdjLTMuMSwzLTQuNyw3LjEtNC44LDExLjNMNDcyLjcsNjUzLjQNCgkJCXoiLz4NCgkJDQoJCQk8bGluZWFyR3JhZGllbnQgaWQ9IlNWR0lEXzdfIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjE5NjMuNTU5IiB5MT0iLTIxMS42MDk2IiB4Mj0iMjAzMS4zNTE2IiB5Mj0iLTI2OC4zMDg4IiBncmFkaWVudFRyYW5zZm9ybT0ibWF0cml4KC0xIDAgMCAxIDI4NzkuMTMwMSA2OTYuNjYpIj4NCgkJCTxzdG9wICBvZmZzZXQ9IjMuNDg4NTc1ZS0wMiIgc3R5bGU9InN0b3AtY29sb3I6IzFCMTQ2NCIvPg0KCQkJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzFCMTQ2NDtzdG9wLW9wYWNpdHk6MCIvPg0KCQk8L2xpbmVhckdyYWRpZW50Pg0KCQk8cGF0aCBjbGFzcz0ic3Q2IiBkPSJNODY3LjksNTAxLjRjNC42LDUuMiw1LjUsMTQuMiwxLjQsMjAuM2MwLDAsNTMuMi01OC4xLDI3LjYtMTIyLjNsLTMzLjctMzMuNWwtNDksODEuNUw4NjcuOSw1MDEuNHoiLz4NCgkJDQoJCQk8bGluZWFyR3JhZGllbnQgaWQ9IlNWR0lEXzhfIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjQ1NS40MDA1IiB5MT0iNTMwLjMwOTMiIHgyPSI0MjMuMTA2OSIgeTI9IjQ4NC41MTEzIiBncmFkaWVudFRyYW5zZm9ybT0ibWF0cml4KDEgMCAwIC0xIDE5Ny4xOTE2IDgzMy45NTcxKSI+DQoJCQk8c3RvcCAgb2Zmc2V0PSIzLjQ4ODU3NWUtMDIiIHN0eWxlPSJzdG9wLWNvbG9yOiMxQjE0NjQiLz4NCgkJCTxzdG9wICBvZmZzZXQ9IjEiIHN0eWxlPSJzdG9wLWNvbG9yOiMxQjE0NjQ7c3RvcC1vcGFjaXR5OjAiLz4NCgkJPC9saW5lYXJHcmFkaWVudD4NCgkJPHBhdGggY2xhc3M9InN0NyIgZD0iTTcwMi4xLDMzNS45Yy02MC01NS4yLTEyNi4xLTI0LjUtMTI2LjEtMjQuNXMtOC43LDgtMTIuMiwxOC42YzguOSw0LjMsNzMuNCw1MC41LDczLjQsNTAuNWwzOC4xLTM4LjENCgkJCUM2ODksMzI1LjgsNzAyLjEsMzM1LjksNzAyLjEsMzM1Ljl6Ii8+DQoJCQ0KCQkJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF85XyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSI1NDYuMzI1MyIgeTE9IjExMC4xMDY0IiB4Mj0iNTcwLjU2MTIiIHkyPSIxNzAuMDU4OSIgZ3JhZGllbnRUcmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAtMSAxOTcuMTkxNiA4MzMuOTU3MSkiPg0KCQkJPHN0b3AgIG9mZnNldD0iMy40ODg1NzVlLTAyIiBzdHlsZT0ic3RvcC1jb2xvcjojMUIxNDY0Ii8+DQoJCQk8c3RvcCAgb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojMUIxNDY0O3N0b3Atb3BhY2l0eTowIi8+DQoJCTwvbGluZWFyR3JhZGllbnQ+DQoJCTxwYXRoIGNsYXNzPSJzdDgiIGQ9Ik03NDEuNiw2NDguOWMwLDAtMzguNCwzOC43LTM4LjUsMzguNWMwLDAtMTAuMyw4LjItMjEuMSwwLjdjMCwwLDYzLjksNTIuNiwxMzIuMiwxOS42bDE5LjktMjBMNzQxLjYsNjQ4Ljl6Ig0KCQkJLz4NCgk8L2c+DQo8L2c+DQo8L3N2Zz4NCg==';
+    readonly supportedTransactionVersions = null;
+    private _connecting: boolean;
+    private _wallet: InfinityWallet | null;
+    private _publicKey: PublicKey | null;
+    private _readyState: WalletReadyState =
+        typeof window === 'undefined' || typeof document === 'undefined'
+            ? WalletReadyState.Unsupported
+            : WalletReadyState.NotDetected;
+
+    constructor(config: InfinityWalletAdapterConfig = {}) {
+        super();
+        this._connecting = false;
+        this._wallet = null;
+        this._publicKey = null;
+
+        if (this._readyState !== WalletReadyState.Unsupported) {
+            scopePollingDetectionStrategy(() => {
+                if (window.infinitywallet?.solana?.isInfinityWallet || window.solana?.isInfinityWallet) {
+                    this._readyState = WalletReadyState.Installed;
+                    this.emit('readyStateChange', this._readyState);
+                    return true;
+                }
+                return false;
+            });
+        }
+    }
+    get publicKey(): PublicKey | null {
+        return this._publicKey;
+    }
+
+    get connecting(): boolean {
+        return this._connecting;
+    }
+
+    get readyState(): WalletReadyState {
+        return this._readyState;
+    }
+
+    async connect(): Promise<void> {
+        try {
+            if (this._connecting) return;
+            if (this._readyState !== WalletReadyState.Installed) throw new WalletNotReadyError();
+
+            this._connecting = true;
+
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const wallet = window.infinitywallet?.solana ?? window.solana!;
+
+            let account: string;
+            try {
+                // @TODO: handle if popup is blocked
+                account = await wallet.getAccount();
+            } catch (error: any) {
+                throw new WalletAccountError(error?.message, error);
+            }
+
+            let publicKey: PublicKey;
+            try {
+                publicKey = new PublicKey(account);
+            } catch (error: any) {
+                throw new WalletPublicKeyError(error?.message, error);
+            }
+
+            window.addEventListener('message', this._messaged);
+
+            this._wallet = wallet;
+            this._publicKey = publicKey;
+
+            this.emit('connect', publicKey);
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        } finally {
+            this._connecting = false;
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        if (this._wallet) {
+            window.removeEventListener('message', this._messaged);
+
+            this._wallet = null;
+            this._publicKey = null;
+        }
+
+        this.emit('disconnect');
+    }
+
+    async signTransaction<T extends Transaction>(transaction: T): Promise<T> {
+        try {
+            const wallet = this._wallet;
+            if (!wallet) throw new WalletNotConnectedError();
+
+            try {
+                return (await wallet.signTransaction(transaction)) as T;
+            } catch (error: any) {
+                throw new WalletSignTransactionError(error?.message, error);
+            }
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+
+    async signAllTransactions<T extends Transaction>(transactions: T[]): Promise<T[]> {
+        try {
+            const wallet = this._wallet;
+            if (!wallet) throw new WalletNotConnectedError();
+
+            try {
+                return (await wallet.signAllTransactions(transactions)) as T[];
+            } catch (error: any) {
+                throw new WalletSignTransactionError(error?.message, error);
+            }
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+    async signMessage(message: Uint8Array): Promise<Uint8Array> {
+        try {
+            const wallet = this._wallet;
+            if (!wallet) throw new WalletNotConnectedError();
+
+            try {
+                const { signature } = await wallet.signMessage(message);
+                return signature;
+            } catch (error: any) {
+                throw new WalletSignMessageError(error?.message, error);
+            }
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+    async sendTransaction(
+        transaction: Transaction,
+        connection: Connection,
+        options: SendTransactionOptions = {}
+    ): Promise<TransactionSignature> {
+        try {
+            const wallet = this._wallet;
+            if (!wallet) throw new WalletNotConnectedError();
+
+            try {
+                const { signature } = await wallet.signAndSendTransaction(transaction);
+                return signature;
+            } catch (error: any) {
+                if (error instanceof WalletError) throw error;
+                throw new WalletSendTransactionError(error?.message, error);
+            }
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+
+    private _messaged = (event: MessageEvent) => {
+        const data = event.data;
+        if (data && data.origin === 'infinitywallet_internal' && data.type === 'lockStatusChanged' && !data.payload) {
+            this._disconnected();
+        }
+    };
+
+    private _disconnected = () => {
+        if (this._wallet) {
+            window.removeEventListener('message', this._messaged);
+
+            this._wallet = null;
+            this._publicKey = null;
+
+            this.emit('error', new WalletDisconnectedError());
+            this.emit('disconnect');
+        }
+    };
+}

--- a/packages/wallets/infinityWallet/src/index.ts
+++ b/packages/wallets/infinityWallet/src/index.ts
@@ -1,0 +1,1 @@
+export * from './adapter';

--- a/packages/wallets/infinityWallet/tsconfig.all.json
+++ b/packages/wallets/infinityWallet/tsconfig.all.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../../tsconfig.root.json",
+    "references": [
+        {
+            "path": "../../core/base/tsconfig.all.json"
+        },
+        {
+            "path": "./tsconfig.cjs.json"
+        },
+        {
+            "path": "./tsconfig.esm.json"
+        }
+    ]
+}

--- a/packages/wallets/infinityWallet/tsconfig.cjs.json
+++ b/packages/wallets/infinityWallet/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../../tsconfig.cjs.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "outDir": "lib/cjs"
+    }
+}

--- a/packages/wallets/infinityWallet/tsconfig.esm.json
+++ b/packages/wallets/infinityWallet/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../../tsconfig.esm.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "outDir": "lib/esm",
+        "declarationDir": "lib/types"
+    }
+}

--- a/packages/wallets/wallets/package.json
+++ b/packages/wallets/wallets/package.json
@@ -49,6 +49,7 @@
         "@solana/wallet-adapter-glow": "workspace:^",
         "@solana/wallet-adapter-huobi": "workspace:^",
         "@solana/wallet-adapter-hyperpay": "workspace:^",
+        "@solana/wallet-adapter-infinitywallet": "workspace:^",
         "@solana/wallet-adapter-keystone": "workspace:^",
         "@solana/wallet-adapter-krystal": "workspace:^",
         "@solana/wallet-adapter-ledger": "workspace:^",

--- a/packages/wallets/wallets/src/index.ts
+++ b/packages/wallets/wallets/src/index.ts
@@ -14,6 +14,7 @@ export * from '@solana/wallet-adapter-fractal';
 export * from '@solana/wallet-adapter-glow';
 export * from '@solana/wallet-adapter-huobi';
 export * from '@solana/wallet-adapter-hyperpay';
+export * from '@solana/wallet-adapter-infinitywallet';
 export * from '@solana/wallet-adapter-keystone';
 export * from '@solana/wallet-adapter-krystal';
 export * from '@solana/wallet-adapter-ledger';

--- a/packages/wallets/wallets/tsconfig.all.json
+++ b/packages/wallets/wallets/tsconfig.all.json
@@ -134,6 +134,9 @@
             "path": "../xdefi/tsconfig.all.json"
         },
         {
+           "path": "../infinitywallet/tsconfig.all.json"
+        },
+        {
             "path": "./tsconfig.cjs.json"
         },
         {

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -161,6 +161,9 @@
             "path": "./packages/wallets/walletconnect/tsconfig.all.json"
         },
         {
+           "path": "./packages/wallets/infinitywallet/tsconfig.all.json"
+        },
+        {
             "path": "./packages/wallets/wallets/tsconfig.all.json"
         },
         {


### PR DESCRIPTION
This PR adds the wallet adapter for the Infinity Wallet, allowing our users to easily connect to Solana DApps via our unique Web3 Browser (removing the need to use a browser-extension wallet) on desktop.

We previously made a PR in August and completed all changes to comply with the standard, however after spending 2 months making the requested changes we then found that the PR had been suddenly closed.

@jordansexton regarding the naming of Infinity it would be wrong as our brand is Infinity Wallet, the same way Math Wallet is named mathWallet in the repo.

The solana name adapter was integrated the exact same way as Phantom. You also mentioned all wallets should be equal and we had an unanswered question regarding this, however we can change it if wallet equality is not a goal of the repo?

All other requested changes including removing the url getter were done many weeks ago, so it would be nice if after all this time you could take a minute to review the completed changes for completion of this PR. Especially after wasting weeks of our teams time!