### PR TITLE
Don't reset state when `adapter` or `onError` changes

### DIFF
--- a/.changeset/dull-badgers-smell.md
+++ b/.changeset/dull-badgers-smell.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-adapter-react': patch
+---
+
+Fix for WalletProvider state being reset when `onError` function changes #637

--- a/packages/core/react/__mocks__/@solana-mobile/wallet-adapter-mobile.ts
+++ b/packages/core/react/__mocks__/@solana-mobile/wallet-adapter-mobile.ts
@@ -1,4 +1,4 @@
-import type { WalletName } from '@solana/wallet-adapter-base';
+import { type WalletName } from '@solana/wallet-adapter-base';
 import { MockWalletAdapter } from '../../src/__mocks__/MockWalletAdapter.js';
 
 export const SolanaMobileWalletAdapterWalletName = 'Solana Mobile Wallet Adapter Name For Tests';

--- a/packages/core/react/src/ConnectionProvider.tsx
+++ b/packages/core/react/src/ConnectionProvider.tsx
@@ -1,7 +1,5 @@
-import type { ConnectionConfig } from '@solana/web3.js';
-import { Connection } from '@solana/web3.js';
-import type { FC, ReactNode } from 'react';
-import React, { useMemo } from 'react';
+import { Connection, type ConnectionConfig } from '@solana/web3.js';
+import React, { useMemo, type FC, type ReactNode } from 'react';
 import { ConnectionContext } from './useConnection.js';
 
 export interface ConnectionProviderProps {

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -5,10 +5,9 @@ import {
     SolanaMobileWalletAdapter,
     SolanaMobileWalletAdapterWalletName,
 } from '@solana-mobile/wallet-adapter-mobile';
-import type { Adapter, WalletError, WalletName } from '@solana/wallet-adapter-base';
+import { type Adapter, type WalletError, type WalletName } from '@solana/wallet-adapter-base';
 import { useStandardWalletAdapters } from '@solana/wallet-standard-wallet-adapter-react';
-import type { ReactNode } from 'react';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import getEnvironment, { Environment } from './getEnvironment.js';
 import getInferredClusterFromEndpoint from './getInferredClusterFromEndpoint.js';
 import { useConnection } from './useConnection.js';

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -122,12 +122,12 @@ export function WalletProviderBase({
         const handleWalletDisconnectEvent = () => {
             if (isUnloadingRef.current) return;
 
+            setPublicKey(null);
             isConnecting.current = false;
             setConnecting(false);
             setConnected(false);
             isDisconnecting.current = false;
             setDisconnecting(false);
-            setPublicKey(null);
         };
 
         const handleWalletErrorEvent = (error: WalletError) => {

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -1,13 +1,15 @@
-import type {
-    Adapter,
-    MessageSignerWalletAdapterProps,
-    SignerWalletAdapterProps,
-    WalletAdapterProps,
-    WalletError,
-    WalletName,
+import {
+    WalletNotConnectedError,
+    WalletNotReadyError,
+    WalletReadyState,
+    type Adapter,
+    type MessageSignerWalletAdapterProps,
+    type SignerWalletAdapterProps,
+    type WalletAdapterProps,
+    type WalletError,
+    type WalletName,
 } from '@solana/wallet-adapter-base';
-import { WalletNotConnectedError, WalletNotReadyError, WalletReadyState } from '@solana/wallet-adapter-base';
-import type { PublicKey } from '@solana/web3.js';
+import { type PublicKey } from '@solana/web3.js';
 import React, { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { WalletNotSelectedError } from './errors.js';
 import { WalletContext } from './useWallet.js';

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -142,13 +142,6 @@ export function WalletProviderBase({
             adapter.off('connect', handleWalletConnectEvent);
             adapter.off('disconnect', handleWalletDisconnectEvent);
             adapter.off('error', handleWalletErrorEvent);
-
-            isConnecting.current = false;
-            setConnecting(false);
-            setConnected(false);
-            isDisconnecting.current = false;
-            setDisconnecting(false);
-            setPublicKey(null);
         };
     }, [adapter, handleError, isUnloadingRef]);
 

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -8,54 +8,58 @@ import type {
 } from '@solana/wallet-adapter-base';
 import { WalletNotConnectedError, WalletNotReadyError, WalletReadyState } from '@solana/wallet-adapter-base';
 import type { PublicKey } from '@solana/web3.js';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { WalletNotSelectedError } from './errors.js';
 import { WalletContext } from './useWallet.js';
-import type { WalletProviderProps } from './WalletProvider.js';
 
-type Props = Readonly<
-    Omit<WalletProviderProps, 'autoConnect' | 'localStorageKey'> & {
-        adapter: Adapter | null;
-        isUnloadingRef: React.RefObject<boolean>;
-        // NOTE: The presence/absence of this handler implies that auto-connect is enabled/disabled.
-        onAutoConnectRequest?: () => Promise<void>;
-        onConnectError: () => void;
-        onSelectWallet: (walletName: WalletName | null) => void;
-    }
->;
+export interface WalletProviderBaseProps {
+    children: ReactNode;
+    wallets: Adapter[];
+    adapter: Adapter | null;
+    isUnloadingRef: React.RefObject<boolean>;
+    // NOTE: The presence/absence of this handler implies that auto-connect is enabled/disabled.
+    onAutoConnectRequest?: () => Promise<void>;
+    onConnectError: () => void;
+    onError?: (error: WalletError, adapter?: Adapter) => void;
+    onSelectWallet: (walletName: WalletName | null) => void;
+}
 
 export function WalletProviderBase({
-    adapter,
     children,
+    wallets: adapters,
+    adapter,
     isUnloadingRef,
     onAutoConnectRequest,
     onConnectError,
-    onError,
+    onError = (error, adapter) => {
+        console.error(error, adapter);
+        if (error instanceof WalletNotReadyError && typeof window !== 'undefined' && adapter) {
+            window.open(adapter.url, '_blank');
+        }
+    },
     onSelectWallet,
-    wallets: adapters,
-}: Props) {
-    const isConnecting = useRef(false);
+}: WalletProviderBaseProps) {
+    const isConnectingRef = useRef(false);
     const [connecting, setConnecting] = useState(false);
-    const isDisconnecting = useRef(false);
+    const isDisconnectingRef = useRef(false);
     const [disconnecting, setDisconnecting] = useState(false);
     const [publicKey, setPublicKey] = useState(() => adapter?.publicKey ?? null);
     const [connected, setConnected] = useState(() => adapter?.connected ?? false);
-    const handleError = useCallback(
-        (error: WalletError, adapter?: Adapter) => {
+
+    const handleErrorRef = useRef((error: WalletError, adapter?: Adapter) => {
+        if (!isUnloadingRef.current) {
+            onError(error, adapter);
+        }
+        return error;
+    });
+    useEffect(() => {
+        handleErrorRef.current = (error, adapter) => {
             if (!isUnloadingRef.current) {
-                if (onError) {
-                    onError(error, adapter);
-                } else {
-                    console.error(error, adapter);
-                    if (error instanceof WalletNotReadyError && typeof window !== 'undefined' && adapter) {
-                        window.open(adapter.url, '_blank');
-                    }
-                }
+                onError(error, adapter);
             }
             return error;
-        },
-        [isUnloadingRef, onError]
-    );
+        };
+    }, [isUnloadingRef, onError]);
 
     // Wrap adapters to conform to the `Wallet` interface
     const [wallets, setWallets] = useState(() =>
@@ -110,63 +114,65 @@ export function WalletProviderBase({
     useEffect(() => {
         if (!adapter) return;
 
-        const handleWalletConnectEvent = (publicKey: PublicKey) => {
+        const handleConnect = (publicKey: PublicKey) => {
             setPublicKey(publicKey);
-            isConnecting.current = false;
+            isConnectingRef.current = false;
             setConnecting(false);
             setConnected(true);
-            isDisconnecting.current = false;
+            isDisconnectingRef.current = false;
             setDisconnecting(false);
         };
 
-        const handleWalletDisconnectEvent = () => {
+        const handleDisconnect = () => {
             if (isUnloadingRef.current) return;
 
             setPublicKey(null);
-            isConnecting.current = false;
+            isConnectingRef.current = false;
             setConnecting(false);
             setConnected(false);
-            isDisconnecting.current = false;
+            isDisconnectingRef.current = false;
             setDisconnecting(false);
         };
 
-        const handleWalletErrorEvent = (error: WalletError) => {
-            handleError(error, adapter);
+        const handleError = (error: WalletError) => {
+            handleErrorRef.current(error, adapter);
         };
 
-        adapter.on('connect', handleWalletConnectEvent);
-        adapter.on('disconnect', handleWalletDisconnectEvent);
-        adapter.on('error', handleWalletErrorEvent);
+        adapter.on('connect', handleConnect);
+        adapter.on('disconnect', handleDisconnect);
+        adapter.on('error', handleError);
 
         return () => {
-            adapter.off('connect', handleWalletConnectEvent);
-            adapter.off('disconnect', handleWalletDisconnectEvent);
-            adapter.off('error', handleWalletErrorEvent);
+            adapter.off('connect', handleConnect);
+            adapter.off('disconnect', handleDisconnect);
+            adapter.off('error', handleError);
+
+            handleDisconnect();
         };
-    }, [adapter, handleError, isUnloadingRef]);
+    }, [adapter, isUnloadingRef]);
 
     // When the adapter changes, clear the `autoConnect` tracking flag
-    const didAttemptAutoConnect = useRef(false);
+    const didAttemptAutoConnectRef = useRef(false);
     useEffect(() => {
         return () => {
-            didAttemptAutoConnect.current = false;
+            didAttemptAutoConnectRef.current = false;
         };
     }, [adapter]);
 
     // If auto-connect is enabled, request to connect when the adapter changes and is ready
     useEffect(() => {
         if (
-            didAttemptAutoConnect.current ||
-            isConnecting.current ||
+            didAttemptAutoConnectRef.current ||
+            isConnectingRef.current ||
             connected ||
             !onAutoConnectRequest ||
             !(wallet?.readyState === WalletReadyState.Installed || wallet?.readyState === WalletReadyState.Loadable)
         ) {
             return;
         }
-        isConnecting.current = true;
+        isConnectingRef.current = true;
         setConnecting(true);
-        didAttemptAutoConnect.current = true;
+        didAttemptAutoConnectRef.current = true;
         (async function () {
             try {
                 await onAutoConnectRequest();
@@ -175,7 +181,7 @@ export function WalletProviderBase({
                 // Drop the error. It will be caught by `handleError` anyway.
             } finally {
                 setConnecting(false);
-                isConnecting.current = false;
+                isConnectingRef.current = false;
             }
         })();
     }, [connected, onAutoConnectRequest, onConnectError, wallet]);
@@ -183,11 +189,11 @@ export function WalletProviderBase({
     // Send a transaction using the provided connection
     const sendTransaction: WalletAdapterProps['sendTransaction'] = useCallback(
         async (transaction, connection, options) => {
-            if (!adapter) throw handleError(new WalletNotSelectedError());
-            if (!connected) throw handleError(new WalletNotConnectedError(), adapter);
+            if (!adapter) throw handleErrorRef.current(new WalletNotSelectedError());
+            if (!connected) throw handleErrorRef.current(new WalletNotConnectedError(), adapter);
             return await adapter.sendTransaction(transaction, connection, options);
         },
-        [adapter, handleError, connected]
+        [adapter, connected]
     );
 
     // Sign a transaction if the wallet supports it
@@ -195,11 +201,11 @@ export function WalletProviderBase({
         () =>
             adapter && 'signTransaction' in adapter
                 ? async (transaction) => {
-                      if (!connected) throw handleError(new WalletNotConnectedError(), adapter);
+                      if (!connected) throw handleErrorRef.current(new WalletNotConnectedError(), adapter);
                       return await adapter.signTransaction(transaction);
                   }
                 : undefined,
-        [adapter, handleError, connected]
+        [adapter, connected]
     );
 
     // Sign multiple transactions if the wallet supports it
@@ -207,11 +213,11 @@ export function WalletProviderBase({
         () =>
             adapter && 'signAllTransactions' in adapter
                 ? async (transactions) => {
-                      if (!connected) throw handleError(new WalletNotConnectedError(), adapter);
+                      if (!connected) throw handleErrorRef.current(new WalletNotConnectedError(), adapter);
                       return await adapter.signAllTransactions(transactions);
                   }
                 : undefined,
-        [adapter, handleError, connected]
+        [adapter, connected]
     );
 
     // Sign an arbitrary message if the wallet supports it
@@ -219,20 +225,20 @@ export function WalletProviderBase({
         () =>
             adapter && 'signMessage' in adapter
                 ? async (message) => {
-                      if (!connected) throw handleError(new WalletNotConnectedError(), adapter);
+                      if (!connected) throw handleErrorRef.current(new WalletNotConnectedError(), adapter);
                       return await adapter.signMessage(message);
                   }
                 : undefined,
-        [adapter, handleError, connected]
+        [adapter, connected]
     );
 
     const handleConnect = useCallback(async () => {
-        if (isConnecting.current || isDisconnecting.current || wallet?.adapter.connected) return;
-        if (!wallet) throw handleError(new WalletNotSelectedError());
+        if (isConnectingRef.current || isDisconnectingRef.current || wallet?.adapter.connected) return;
+        if (!wallet) throw handleErrorRef.current(new WalletNotSelectedError());
         const { adapter, readyState } = wallet;
         if (!(readyState === WalletReadyState.Installed || readyState === WalletReadyState.Loadable))
-            throw handleError(new WalletNotReadyError(), adapter);
-        isConnecting.current = true;
+            throw handleErrorRef.current(new WalletNotReadyError(), adapter);
+        isConnectingRef.current = true;
         setConnecting(true);
         try {
             await adapter.connect();
@@ -241,20 +247,20 @@ export function WalletProviderBase({
             throw e;
         } finally {
             setConnecting(false);
-            isConnecting.current = false;
+            isConnectingRef.current = false;
         }
-    }, [handleError, onConnectError, wallet]);
+    }, [onConnectError, wallet]);
 
     const handleDisconnect = useCallback(async () => {
-        if (isDisconnecting.current) return;
+        if (isDisconnectingRef.current) return;
         if (!adapter) return;
-        isDisconnecting.current = true;
+        isDisconnectingRef.current = true;
         setDisconnecting(true);
         try {
             await adapter.disconnect();
         } finally {
             setDisconnecting(false);
-            isDisconnecting.current = false;
+            isDisconnectingRef.current = false;
         }
     }, [adapter]);
 

--- a/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
@@ -4,16 +4,20 @@
 
 'use strict';
 
-import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
-import { BaseWalletAdapter, WalletError, WalletNotReadyError, WalletReadyState } from '@solana/wallet-adapter-base';
+import {
+    BaseWalletAdapter,
+    WalletError,
+    WalletNotReadyError,
+    WalletReadyState,
+    type Adapter,
+    type WalletName,
+} from '@solana/wallet-adapter-base';
 import { PublicKey } from '@solana/web3.js';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
-import type { WalletContextState } from '../useWallet.js';
-import { useWallet } from '../useWallet.js';
-import type { WalletProviderBaseProps } from '../WalletProviderBase.js';
-import { WalletProviderBase } from '../WalletProviderBase.js';
+import { useWallet, type WalletContextState } from '../useWallet.js';
+import { WalletProviderBase, type WalletProviderBaseProps } from '../WalletProviderBase.js';
 
 type TestRefType = {
     getWalletContextState(): WalletContextState;

--- a/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
@@ -276,6 +276,28 @@ describe('WalletProviderBase', () => {
             });
             expect(onError).not.toBeCalled();
         });
+        describe('when a wallet is connected', () => {
+            beforeEach(async () => {
+                await act(() => {
+                    ref.current?.getWalletContextState().connect();
+                });
+                expect(ref.current?.getWalletContextState()).toMatchObject({
+                    connected: true,
+                });
+            });
+            describe('then the `onError` function changes', () => {
+                beforeEach(async () => {
+                    const differentOnError = jest.fn(); /* Some function, different from the one above */
+                    renderTest({ adapter: fooWalletAdapter, onError: differentOnError });
+                });
+                it('does not cause state to be cleared when it changes', () => {
+                    // Regression test for https://github.com/solana-labs/wallet-adapter/issues/636
+                    expect(ref.current?.getWalletContextState()).toMatchObject({
+                        connected: true,
+                    });
+                });
+            });
+        });
     });
     describe('connect()', () => {
         describe('given an adapter that is not ready', () => {

--- a/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
@@ -6,14 +6,13 @@
 
 import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
 import { BaseWalletAdapter, WalletError, WalletNotReadyError, WalletReadyState } from '@solana/wallet-adapter-base';
-
 import { PublicKey } from '@solana/web3.js';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import type { WalletContextState } from '../useWallet.js';
 import { useWallet } from '../useWallet.js';
-import type { WalletProviderProps } from '../WalletProvider.js';
+import type { WalletProviderBaseProps } from '../WalletProviderBase.js';
 import { WalletProviderBase } from '../WalletProviderBase.js';
 
 type TestRefType = {
@@ -45,19 +44,19 @@ describe('WalletProviderBase', () => {
     let isUnloading: React.MutableRefObject<boolean>;
 
     function renderTest(
-        props: Omit<WalletProviderProps, 'autoConnect' | 'children' | 'wallets'> & {
-            adapter: Adapter | null;
-            onAutoConnectRequest?: () => Promise<void>;
-        }
+        props: Omit<
+            WalletProviderBaseProps,
+            'children' | 'wallets' | 'isUnloadingRef' | 'onConnectError' | 'onSelectWallet'
+        >
     ) {
         act(() => {
             root.render(
                 <WalletProviderBase
-                    {...props}
+                    wallets={adapters}
+                    isUnloadingRef={isUnloading}
                     onConnectError={jest.fn()}
                     onSelectWallet={jest.fn()}
-                    isUnloadingRef={isUnloading}
-                    wallets={adapters}
+                    {...props}
                 >
                     <TestComponent ref={ref} />
                 </WalletProviderBase>
@@ -260,7 +259,7 @@ describe('WalletProviderBase', () => {
         let onError: jest.Mock;
         beforeEach(async () => {
             onError = jest.fn();
-            renderTest({ onError, adapter: fooWalletAdapter });
+            renderTest({ adapter: fooWalletAdapter, onError });
         });
         it('gets called in response to adapter errors', () => {
             act(() => {

--- a/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
@@ -4,20 +4,20 @@
 
 'use strict';
 
-import type { AddressSelector, AuthorizationResultCache } from '@solana-mobile/wallet-adapter-mobile';
-import { SolanaMobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile';
-import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
-import { WalletError, WalletReadyState } from '@solana/wallet-adapter-base';
+import {
+    SolanaMobileWalletAdapter,
+    type AddressSelector,
+    type AuthorizationResultCache,
+} from '@solana-mobile/wallet-adapter-mobile';
+import { WalletError, WalletReadyState, type Adapter, type WalletName } from '@solana/wallet-adapter-base';
 import { PublicKey } from '@solana/web3.js';
 import 'jest-localstorage-mock';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { MockWalletAdapter } from '../__mocks__/MockWalletAdapter.js';
-import type { WalletContextState } from '../useWallet.js';
-import { useWallet } from '../useWallet.js';
-import type { WalletProviderProps } from '../WalletProvider.js';
-import { WalletProvider } from '../WalletProvider.js';
+import { useWallet, type WalletContextState } from '../useWallet.js';
+import { WalletProvider, type WalletProviderProps } from '../WalletProvider.js';
 
 jest.mock('../getEnvironment.js', () => ({
     ...jest.requireActual('../getEnvironment.js'),

--- a/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
@@ -6,10 +6,8 @@
 
 import type { AddressSelector, AuthorizationResultCache } from '@solana-mobile/wallet-adapter-mobile';
 import { SolanaMobileWalletAdapter, SolanaMobileWalletAdapterWalletName } from '@solana-mobile/wallet-adapter-mobile';
-
 import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
 import { BaseWalletAdapter, WalletError, WalletReadyState } from '@solana/wallet-adapter-base';
-
 import type { Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import 'jest-localstorage-mock';

--- a/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
@@ -4,21 +4,27 @@
 
 'use strict';
 
-import type { AddressSelector, AuthorizationResultCache } from '@solana-mobile/wallet-adapter-mobile';
-import { SolanaMobileWalletAdapter, SolanaMobileWalletAdapterWalletName } from '@solana-mobile/wallet-adapter-mobile';
-import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
-import { BaseWalletAdapter, WalletError, WalletReadyState } from '@solana/wallet-adapter-base';
-import type { Connection } from '@solana/web3.js';
-import { PublicKey } from '@solana/web3.js';
+import {
+    SolanaMobileWalletAdapter,
+    SolanaMobileWalletAdapterWalletName,
+    type AddressSelector,
+    type AuthorizationResultCache,
+} from '@solana-mobile/wallet-adapter-mobile';
+import {
+    BaseWalletAdapter,
+    WalletError,
+    WalletReadyState,
+    type Adapter,
+    type WalletName,
+} from '@solana/wallet-adapter-base';
+import { PublicKey, type Connection } from '@solana/web3.js';
 import 'jest-localstorage-mock';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { useConnection } from '../useConnection.js';
-import type { WalletContextState } from '../useWallet.js';
-import { useWallet } from '../useWallet.js';
-import type { WalletProviderProps } from '../WalletProvider.js';
-import { WalletProvider } from '../WalletProvider.js';
+import { useWallet, type WalletContextState } from '../useWallet.js';
+import { WalletProvider, type WalletProviderProps } from '../WalletProvider.js';
 
 jest.mock('../getEnvironment.js', () => ({
     ...jest.requireActual('../getEnvironment.js'),

--- a/packages/core/react/src/__tests__/getEnvironment-test.ts
+++ b/packages/core/react/src/__tests__/getEnvironment-test.ts
@@ -1,5 +1,4 @@
-import type { Adapter } from '@solana/wallet-adapter-base';
-import { WalletReadyState } from '@solana/wallet-adapter-base';
+import { WalletReadyState, type Adapter } from '@solana/wallet-adapter-base';
 import getEnvironment, { Environment } from '../getEnvironment.js';
 
 describe('getEnvironment()', () => {

--- a/packages/core/react/src/getEnvironment.ts
+++ b/packages/core/react/src/getEnvironment.ts
@@ -1,6 +1,5 @@
 import { SolanaMobileWalletAdapterWalletName } from '@solana-mobile/wallet-adapter-mobile';
-import type { Adapter } from '@solana/wallet-adapter-base';
-import { WalletReadyState } from '@solana/wallet-adapter-base';
+import { WalletReadyState, type Adapter } from '@solana/wallet-adapter-base';
 
 export enum Environment {
     DESKTOP_WEB,

--- a/packages/core/react/src/getInferredClusterFromEndpoint.ts
+++ b/packages/core/react/src/getInferredClusterFromEndpoint.ts
@@ -1,4 +1,4 @@
-import type { Cluster } from '@solana/web3.js';
+import { type Cluster } from '@solana/web3.js';
 
 export default function getInferredClusterFromEndpoint(endpoint?: string): Cluster {
     if (!endpoint) {

--- a/packages/core/react/src/useAnchorWallet.ts
+++ b/packages/core/react/src/useAnchorWallet.ts
@@ -1,4 +1,4 @@
-import type { PublicKey, Transaction } from '@solana/web3.js';
+import { type PublicKey, type Transaction } from '@solana/web3.js';
 import { useMemo } from 'react';
 import { useWallet } from './useWallet.js';
 

--- a/packages/core/react/src/useConnection.tsx
+++ b/packages/core/react/src/useConnection.tsx
@@ -1,4 +1,4 @@
-import type { Connection } from '@solana/web3.js';
+import { type Connection } from '@solana/web3.js';
 import { createContext, useContext } from 'react';
 
 export interface ConnectionContextState {

--- a/packages/core/react/src/useLocalStorage.native.ts
+++ b/packages/core/react/src/useLocalStorage.native.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { useLocalStorage as baseUseLocalStorage } from './useLocalStorage.js';
+import { type useLocalStorage as baseUseLocalStorage } from './useLocalStorage.js';
 
 export const useLocalStorage: typeof baseUseLocalStorage = function useLocalStorage<T>(
     _key: string,

--- a/packages/core/react/src/useLocalStorage.ts
+++ b/packages/core/react/src/useLocalStorage.ts
@@ -1,5 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 
 export function useLocalStorage<T>(key: string, defaultState: T): [T, Dispatch<SetStateAction<T>>] {
     const state = useState<T>(() => {

--- a/packages/core/react/src/useLocalStorage.ts
+++ b/packages/core/react/src/useLocalStorage.ts
@@ -16,10 +16,10 @@ export function useLocalStorage<T>(key: string, defaultState: T): [T, Dispatch<S
     });
     const value = state[0];
 
-    const isFirstRender = useRef(true);
+    const isFirstRenderRef = useRef(true);
     useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
+        if (isFirstRenderRef.current) {
+            isFirstRenderRef.current = false;
             return;
         }
         try {

--- a/packages/core/react/src/useWallet.ts
+++ b/packages/core/react/src/useWallet.ts
@@ -1,13 +1,13 @@
-import type {
-    Adapter,
-    MessageSignerWalletAdapterProps,
-    SendTransactionOptions,
-    SignerWalletAdapterProps,
-    WalletAdapterProps,
-    WalletName,
-    WalletReadyState,
+import {
+    type Adapter,
+    type MessageSignerWalletAdapterProps,
+    type SendTransactionOptions,
+    type SignerWalletAdapterProps,
+    type WalletAdapterProps,
+    type WalletName,
+    type WalletReadyState,
 } from '@solana/wallet-adapter-base';
-import type { Connection, PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
+import { type Connection, type PublicKey, type Transaction, type VersionedTransaction } from '@solana/web3.js';
 import { createContext, useContext } from 'react';
 
 export interface Wallet {


### PR DESCRIPTION
Fixes https://github.com/solana-labs/wallet-adapter/issues/636

Now that we're not wiping the state when the adapter changes, we'll need to check the logic in all the other places this should happen.