### PR TITLE
UI tweaks for wallet modal/dialog

### DIFF
--- a/.changeset/two-vans-end.md
+++ b/.changeset/two-vans-end.md
@@ -1,0 +1,8 @@
+---
+'@solana/wallet-adapter-example': patch
+'@solana/wallet-adapter-ant-design': patch
+'@solana/wallet-adapter-material-ui': patch
+'@solana/wallet-adapter-react-ui': patch
+---
+
+UI tweaks for wallet modal/dialogs

--- a/packages/ui/ant-design/src/WalletModal.tsx
+++ b/packages/ui/ant-design/src/WalletModal.tsx
@@ -1,6 +1,6 @@
 import type { WalletName } from '@solana/wallet-adapter-base';
 import { WalletReadyState } from '@solana/wallet-adapter-base';
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWallet, type Wallet } from '@solana/wallet-adapter-react';
 import type { ModalProps } from 'antd';
 import { Menu, Modal } from 'antd';
 import type { FC, MouseEvent } from 'react';
@@ -23,8 +23,22 @@ export const WalletModal: FC<WalletModalProps> = ({
     const [expanded, setExpanded] = useState(false);
 
     const [featured, more] = useMemo(() => {
-        const supportedWallets = wallets.filter((wallet) => wallet.readyState !== WalletReadyState.Unsupported);
-        return [supportedWallets.slice(0, featuredWallets), supportedWallets.slice(featuredWallets)];
+        const installed: Wallet[] = [];
+        const loadable: Wallet[] = [];
+        const notDetected: Wallet[] = [];
+
+        for (const wallet of wallets) {
+            if (wallet.readyState === WalletReadyState.NotDetected) {
+                notDetected.push(wallet);
+            } else if (wallet.readyState === WalletReadyState.Loadable) {
+                loadable.push(wallet);
+            } else if (wallet.readyState === WalletReadyState.Installed) {
+                installed.push(wallet);
+            }
+        }
+
+        const orderedWallets = [...installed, ...loadable, ...notDetected];
+        return [orderedWallets.slice(0, featuredWallets), orderedWallets.slice(featuredWallets)];
     }, [wallets, featuredWallets]);
 
     const handleCancel = useCallback(

--- a/packages/ui/material-ui/src/WalletDialog.tsx
+++ b/packages/ui/material-ui/src/WalletDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import type { WalletName } from '@solana/wallet-adapter-base';
 import { WalletReadyState } from '@solana/wallet-adapter-base';
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWallet, type Wallet } from '@solana/wallet-adapter-react';
 import type { FC, ReactElement, SyntheticEvent } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useWalletDialog } from './useWalletDialog.js';
@@ -89,8 +89,22 @@ export const WalletDialog: FC<WalletDialogProps> = ({
     const [expanded, setExpanded] = useState(false);
 
     const [featured, more] = useMemo(() => {
-        const supportedWallets = wallets.filter((wallet) => wallet.readyState !== WalletReadyState.Unsupported);
-        return [supportedWallets.slice(0, featuredWallets), supportedWallets.slice(featuredWallets)];
+        const installed: Wallet[] = [];
+        const loadable: Wallet[] = [];
+        const notDetected: Wallet[] = [];
+
+        for (const wallet of wallets) {
+            if (wallet.readyState === WalletReadyState.NotDetected) {
+                notDetected.push(wallet);
+            } else if (wallet.readyState === WalletReadyState.Loadable) {
+                loadable.push(wallet);
+            } else if (wallet.readyState === WalletReadyState.Installed) {
+                installed.push(wallet);
+            }
+        }
+
+        const orderedWallets = [...installed, ...loadable, ...notDetected];
+        return [orderedWallets.slice(0, featuredWallets), orderedWallets.slice(featuredWallets)];
     }, [wallets, featuredWallets]);
 
     const handleClose = useCallback(

--- a/packages/ui/react-ui/src/WalletModal.tsx
+++ b/packages/ui/react-ui/src/WalletModal.tsx
@@ -41,16 +41,6 @@ export const WalletModal: FC<WalletModalProps> = ({ className = '', container = 
         return [installed, loadable, notDetected];
     }, [wallets]);
 
-    const getStartedWallet = useMemo(() => {
-        const otherWallets = [...loadableWallets, ...notDetectedWallets];
-        return installedWallets.length
-            ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              installedWallets[0]!
-            : wallets.find((wallet: { readyState: any }) => wallet.readyState === WalletReadyState.Loadable) ||
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  otherWallets[0]!;
-    }, [installedWallets, wallets, loadableWallets, notDetectedWallets]);
-
     const hideModal = useCallback(() => {
         setFadeIn(false);
         setTimeout(() => setVisible(false), 150);
@@ -214,13 +204,6 @@ export const WalletModal: FC<WalletModalProps> = ({ className = '', container = 
                                 </h1>
                                 <div className="wallet-adapter-modal-middle">
                                     <WalletSVG />
-                                    <button
-                                        type="button"
-                                        className="wallet-adapter-modal-middle-button"
-                                        onClick={(event) => handleWalletClick(event, getStartedWallet.adapter.name)}
-                                    >
-                                        Get started
-                                    </button>
                                 </div>
                                 {collapsedWallets.length ? (
                                     <>

--- a/packages/ui/react-ui/src/WalletModal.tsx
+++ b/packages/ui/react-ui/src/WalletModal.tsx
@@ -23,10 +23,10 @@ export const WalletModal: FC<WalletModalProps> = ({ className = '', container = 
     const [fadeIn, setFadeIn] = useState(false);
     const [portal, setPortal] = useState<Element | null>(null);
 
-    const [installedWallets, loadableWallets, notDetectedWallets] = useMemo(() => {
+    const [listedWallets, collapsedWallets] = useMemo(() => {
         const installed: Wallet[] = [];
-        const notDetected: Wallet[] = [];
         const loadable: Wallet[] = [];
+        const notDetected: Wallet[] = [];
 
         for (const wallet of wallets) {
             if (wallet.readyState === WalletReadyState.NotDetected) {
@@ -38,7 +38,20 @@ export const WalletModal: FC<WalletModalProps> = ({ className = '', container = 
             }
         }
 
-        return [installed, loadable, notDetected];
+        let listed: Wallet[] = [];
+        let collapsed: Wallet[] = [];
+
+        if (installed.length) {
+            listed = installed;
+            collapsed = [...loadable, ...notDetected];
+        } else if (loadable.length) {
+            listed = loadable;
+            collapsed = notDetected;
+        } else {
+            collapsed = notDetected;
+        }
+
+        return [listed, collapsed];
     }, [wallets]);
 
     const hideModal = useCallback(() => {
@@ -119,19 +132,6 @@ export const WalletModal: FC<WalletModalProps> = ({ className = '', container = 
     }, [hideModal, handleTabKey]);
 
     useLayoutEffect(() => setPortal(document.querySelector(container)), [container]);
-
-    let listedWallets: Wallet[] = [];
-    let collapsedWallets: Wallet[] = [];
-
-    if (installedWallets.length) {
-        listedWallets = installedWallets;
-        collapsedWallets = [...loadableWallets, ...notDetectedWallets];
-    } else if (loadableWallets.length) {
-        listedWallets = loadableWallets;
-        collapsedWallets = notDetectedWallets;
-    } else {
-        collapsedWallets = notDetectedWallets;
-    }
 
     return (
         portal &&


### PR DESCRIPTION
- Remove the Get Started button from the react wallet modal. It's not currently serving new users well to point them to an essentially random wallet with no expanation

- Update the ordering of wallets on the material UI and ant design modal/dialog. They now sort Installed first, then Loadable, then NotDetected. This is the same behaviour we have on the react one after the recent tweaks.

Eg with 4 wallets (Phantom, Glow, Solflare, burner), in that order, none installed, Solflare + burner are loadable:

| Material UI | Ant Design | React UI |
| ---              | ---               | ---          |
|  <img width="340" alt="deeplink-material-ui" src="https://user-images.githubusercontent.com/1711350/207897479-d6477750-f2ce-4a45-b248-40a30c719c06.png"> |  <img width="337" alt="deeplink-ant-design" src="https://user-images.githubusercontent.com/1711350/207897541-067a8a99-2052-4433-9836-36e7cedfd3bf.png"> |  <img width="417" alt="deeplink-react-ui" src="https://user-images.githubusercontent.com/1711350/207897607-b304c348-c98c-412d-b8e5-7fe481d67dbb.png">  |

Closes #394 (albeit by removing Get Started) 