### PR TITLE
Wallet adapter no longer accidentally disconnects when in React Strict Mode

### DIFF
--- a/.changeset/hip-wombats-check.md
+++ b/.changeset/hip-wombats-check.md
@@ -1,0 +1,5 @@
+---
+"@solana/wallet-adapter-react": patch
+---
+
+Wallet adapter no longer accidentally disconnects upon refreshing the page when in React Strict Mode.

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -87,7 +87,10 @@ export function WalletProvider({
         [adaptersWithMobileWalletAdapter, walletName]
     );
     const changeWallet = useCallback(
-        (walletName: WalletName<string> | null) => {
+        (nextWalletName: WalletName<string> | null) => {
+            if (walletName === nextWalletName) {
+                return;
+            }
             if (
                 adapter &&
                 // Selecting a wallet other than the mobile wallet adapter is not
@@ -98,9 +101,9 @@ export function WalletProvider({
             ) {
                 adapter.disconnect();
             }
-            setWalletName(walletName);
+            setWalletName(nextWalletName);
         },
-        [adapter, setWalletName]
+        [adapter, setWalletName, walletName]
     );
     useEffect(() => {
         if (adapter == null) {

--- a/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
@@ -293,6 +293,17 @@ describe('WalletProvider when the environment is `DESKTOP_WEB`', () => {
                     expect(fooWalletAdapter.disconnect).toHaveBeenCalled();
                 });
             });
+            describe('and you select the same wallet', () => {
+                beforeEach(async () => {
+                    await act(async () => {
+                        ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
+                        await Promise.resolve(); // Flush all promises in effects after calling `select()`.
+                    });
+                });
+                it('should not disconnect the old wallet', () => {
+                    expect(fooWalletAdapter.disconnect).not.toHaveBeenCalled();
+                });
+            });
             describe('once disconnected', () => {
                 beforeEach(async () => {
                     jest.clearAllMocks();

--- a/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
@@ -388,6 +388,17 @@ describe('WalletProvider when the environment is `MOBILE_WEB`', () => {
                     expect(fooWalletAdapter.disconnect).toHaveBeenCalled();
                 });
             });
+            describe('and you select the same wallet', () => {
+                beforeEach(async () => {
+                    await act(async () => {
+                        ref.current?.getWalletContextState().select('FooWallet' as WalletName<'FooWallet'>);
+                        await Promise.resolve(); // Flush all promises in effects after calling `select()`.
+                    });
+                });
+                it('should not disconnect the old wallet', () => {
+                    expect(fooWalletAdapter.disconnect).not.toHaveBeenCalled();
+                });
+            });
             describe('once disconnected', () => {
                 beforeEach(async () => {
                     jest.clearAllMocks();


### PR DESCRIPTION
We were being extremely lazy here with respect to calling `disconnect` when a wallet is changed. Instead of calling `disconnect()` in an effect as a _consequence_ of the wallet name changing, just call disconnect in tandem with the wallet name being changed.

#### Test plan

1. Open the starter/example or starter/nextjs-example locally, in dev mode (won't work in prod mode)
2. Connect to glow or backpack
3. Refresh the page

Observe that the selected wallet is recalled between refreshes.

Fixes #686. 