### PR TITLE
Add support for redirecting to Solflare browser on iOS

### DIFF
--- a/.changeset/smooth-items-itch.md
+++ b/.changeset/smooth-items-itch.md
@@ -1,0 +1,6 @@
+---
+'@solana/wallet-adapter-solflare': patch
+'@solana/wallet-adapter-phantom': patch
+---
+
+Add support for redirecting to Solflare browser on iOS

--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -131,8 +131,8 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
             if (this.readyState === WalletReadyState.Loadable) {
                 // redirect to the Phantom /browse universal link
                 // this will open the current URL in the Phantom in-wallet browser
-                const url = encodeURI(window.location.href);
-                const ref = encodeURI(window.location.origin);
+                const url = encodeURIComponent(window.location.href);
+                const ref = encodeURIComponent(window.location.origin);
                 window.location.href = `https://phantom.app/ul/browse/${url}?ref=${ref}`;
                 return;
             }


### PR DESCRIPTION
Solflare has added support for deep-linking to their browser, so we can redirect from iOS Safari into their in-wallet browser as we do with Phantom:

https://user-images.githubusercontent.com/1711350/213165562-16094a11-d37c-48ed-b004-af3727327b95.mov

While testing I found some bugs in Solflare which I've reported to them, but I don't think they should block us shipping this.

- Can make it hang when opening a browse deeplink
- Wallet selection isn't remembered when Solflare app is closed

Also updated to use `encodeURIComponent` when building the URL, Phantom was more lenient but the previous code didn't URL encode correctly