### PR TITLE
Uses default import for @mui/icons-material

### DIFF
--- a/packages/ui/material-ui/src/WalletDialog.tsx
+++ b/packages/ui/material-ui/src/WalletDialog.tsx
@@ -1,4 +1,7 @@
-import { Close as CloseIcon, ExpandLess as CollapseIcon, ExpandMore as ExpandIcon } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
+import CollapseIcon from '@mui/icons-material/ExpandLess';
+import ExpandIcon from '@mui/icons-material/ExpandMore';
+
 import type { DialogProps, Theme } from '@mui/material';
 import {
     Button,

--- a/packages/ui/material-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/material-ui/src/WalletMultiButton.tsx
@@ -1,4 +1,7 @@
-import { FileCopy as CopyIcon, LinkOff as DisconnectIcon, SwapHoriz as SwitchIcon } from '@mui/icons-material';
+import CopyIcon from '@mui/icons-material/FileCopy';
+import DisconnectIcon from '@mui/icons-material/LinkOff';
+import SwitchIcon from '@mui/icons-material/SwapHoriz';
+
 import type { ButtonProps, Theme } from '@mui/material';
 import { Button, Collapse, Fade, ListItemIcon, Menu, MenuItem, styled } from '@mui/material';
 import { useWallet } from '@solana/wallet-adapter-react';


### PR DESCRIPTION
Currently @mui/icons-material does not allow tree-shaking on named imports. When using NextJS HMR this slows down immensely dev time as each page rendered is compiled on file change and this package is including all icons from @mui/icons-material. With this PR the bundle is reduced immensely. 