### PR TITLE
The Phantom app on Android and iOS is not exposing isConnected so thi…

### DIFF
--- a/.changeset/hungry-geckos-beg.md
+++ b/.changeset/hungry-geckos-beg.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-adapter-phantom': patch
+---
+
+Fix for Phantom adapter's `connected` state

--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -108,10 +108,6 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
         return this._connecting;
     }
 
-    get connected() {
-        return !!this._wallet?.isConnected;
-    }
-
     get readyState() {
         return this._readyState;
     }


### PR DESCRIPTION
The Phantom app on Android and iOS is not exposing isConnected so this is crashing, revert to the default implementation of connected()