### PR TITLE
fix: patch around MUI icons failure to work in ESM project

### DIFF
--- a/.changeset/proud-trees-destroy.md
+++ b/.changeset/proud-trees-destroy.md
@@ -1,0 +1,6 @@
+---
+"@solana/wallet-adapter-example": patch
+"@solana/wallet-adapter-material-ui": patch
+---
+
+Updated imports of Material UI icons in such a way that sidesteps the problem described here: https://github.com/mui/material-ui/issues/35233

--- a/packages/starter/example/src/components/notify.tsx
+++ b/packages/starter/example/src/components/notify.tsx
@@ -1,4 +1,7 @@
-import LaunchIcon from '@mui/icons-material/Launch';
+import {
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    Launch as LaunchIcon,
+} from '@mui/icons-material';
 import { Link } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import type { VariantType } from 'notistack';

--- a/packages/ui/material-ui/src/WalletDialog.tsx
+++ b/packages/ui/material-ui/src/WalletDialog.tsx
@@ -1,7 +1,11 @@
-import CloseIcon from '@mui/icons-material/Close';
-import CollapseIcon from '@mui/icons-material/ExpandLess';
-import ExpandIcon from '@mui/icons-material/ExpandMore';
-
+import {
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    Close as CloseIcon,
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    ExpandLess as CollapseIcon,
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    ExpandMore as ExpandIcon,
+} from '@mui/icons-material';
 import type { DialogProps, Theme } from '@mui/material';
 import {
     Button,

--- a/packages/ui/material-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/material-ui/src/WalletMultiButton.tsx
@@ -1,7 +1,11 @@
-import CopyIcon from '@mui/icons-material/FileCopy';
-import DisconnectIcon from '@mui/icons-material/LinkOff';
-import SwitchIcon from '@mui/icons-material/SwapHoriz';
-
+import {
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    FileCopy as CopyIcon,
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    LinkOff as DisconnectIcon,
+    // FIXME(https://github.com/mui/material-ui/issues/35233)
+    SwapHoriz as SwitchIcon,
+} from '@mui/icons-material';
 import type { ButtonProps, Theme } from '@mui/material';
 import { Button, Collapse, Fade, ListItemIcon, Menu, MenuItem, styled } from '@mui/material';
 import { useWallet } from '@solana/wallet-adapter-react';


### PR DESCRIPTION
Broken: https://github.com/solana-labs/wallet-adapter/commit/54061676920bccfdcb350298b1cc070c38f92a87#r101354991
Reason: https://github.com/mui/material-ui/issues/35233

Fixes #729.