### PR TITLE
fix: type errors

### DIFF
--- a/packages/core/base/src/adapter.ts
+++ b/packages/core/base/src/adapter.ts
@@ -1,6 +1,7 @@
 import type { Connection, PublicKey, SendOptions, Signer, Transaction, TransactionSignature } from '@solana/web3.js';
 import EventEmitter from 'eventemitter3';
-import { type WalletError, WalletNotConnectedError } from './errors.js';
+import type { WalletError } from './errors.js';
+import { WalletNotConnectedError } from './errors.js';
 import type { SupportedTransactionVersions, TransactionOrVersionedTransaction } from './transaction.js';
 
 export { EventEmitter };

--- a/packages/core/base/src/signer.ts
+++ b/packages/core/base/src/signer.ts
@@ -1,12 +1,9 @@
 import type { Connection, TransactionSignature } from '@solana/web3.js';
-import {
-    BaseWalletAdapter,
-    type SendTransactionOptions,
-    type WalletAdapter,
-    type WalletAdapterProps,
-} from './adapter.js';
+import type { SendTransactionOptions, WalletAdapter, WalletAdapterProps } from './adapter.js';
+import { BaseWalletAdapter } from './adapter.js';
 import { WalletSendTransactionError, WalletSignTransactionError } from './errors.js';
-import { isVersionedTransaction, type TransactionOrVersionedTransaction } from './transaction.js';
+import type { TransactionOrVersionedTransaction } from './transaction.js';
+import { isVersionedTransaction } from './transaction.js';
 
 export interface SignerWalletAdapterProps<Name extends string = string> extends WalletAdapterProps<Name> {
     signTransaction<T extends TransactionOrVersionedTransaction<this['supportedTransactionVersions']>>(

--- a/packages/core/base/src/standard.ts
+++ b/packages/core/base/src/standard.ts
@@ -1,17 +1,15 @@
-import {
-    SolanaSignAndSendTransaction,
-    type SolanaSignAndSendTransactionFeature,
-    type SolanaSignMessageFeature,
-    SolanaSignTransaction,
-    type SolanaSignTransactionFeature,
+import type {
+    SolanaSignAndSendTransactionFeature,
+    SolanaSignMessageFeature,
+    SolanaSignTransactionFeature,
 } from '@solana/wallet-standard-features';
+import { SolanaSignAndSendTransaction, SolanaSignTransaction } from '@solana/wallet-standard-features';
 import type { Wallet as StandardWallet, WalletWithFeatures as StandardWalletWithFeatures } from '@wallet-standard/base';
-import {
-    StandardConnect,
-    type StandardConnectFeature,
-    type StandardDisconnectFeature,
-    StandardEvents,
-    type StandardEventsFeature,
+import { StandardConnect, StandardEvents } from '@wallet-standard/features';
+import type {
+    StandardConnectFeature,
+    StandardDisconnectFeature,
+    StandardEventsFeature,
 } from '@wallet-standard/features';
 import type { WalletAdapter, WalletAdapterProps } from './adapter.js';
 

--- a/packages/core/react/__mocks__/@solana-mobile/wallet-adapter-mobile.ts
+++ b/packages/core/react/__mocks__/@solana-mobile/wallet-adapter-mobile.ts
@@ -1,4 +1,4 @@
-import { type WalletName } from '@solana/wallet-adapter-base';
+import type { WalletName } from '@solana/wallet-adapter-base';
 import { MockWalletAdapter } from '../../src/__mocks__/MockWalletAdapter.js';
 
 export const SolanaMobileWalletAdapterWalletName = 'Solana Mobile Wallet Adapter Name For Tests';

--- a/packages/core/react/src/ConnectionProvider.tsx
+++ b/packages/core/react/src/ConnectionProvider.tsx
@@ -1,5 +1,7 @@
-import { Connection, type ConnectionConfig } from '@solana/web3.js';
-import React, { type FC, type ReactNode, useMemo } from 'react';
+import type { ConnectionConfig } from '@solana/web3.js';
+import { Connection } from '@solana/web3.js';
+import type { FC, ReactNode } from 'react';
+import React, { useMemo } from 'react';
 import { ConnectionContext } from './useConnection.js';
 
 export interface ConnectionProviderProps {

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -5,9 +5,10 @@ import {
     SolanaMobileWalletAdapter,
     SolanaMobileWalletAdapterWalletName,
 } from '@solana-mobile/wallet-adapter-mobile';
-import { type Adapter, type WalletError, type WalletName } from '@solana/wallet-adapter-base';
+import type { Adapter, WalletError, WalletName } from '@solana/wallet-adapter-base';
 import { useStandardWalletAdapters } from '@solana/wallet-standard-wallet-adapter-react';
-import React, { type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { ReactNode } from 'react';
 import getEnvironment, { Environment } from './getEnvironment.js';
 import getInferredClusterFromEndpoint from './getInferredClusterFromEndpoint.js';
 import { useConnection } from './useConnection.js';

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -1,16 +1,15 @@
-import {
-    type Adapter,
-    type MessageSignerWalletAdapterProps,
-    type SignerWalletAdapterProps,
-    type WalletAdapterProps,
-    type WalletError,
-    type WalletName,
-    WalletNotConnectedError,
-    WalletNotReadyError,
-    WalletReadyState,
+import type {
+    Adapter,
+    MessageSignerWalletAdapterProps,
+    SignerWalletAdapterProps,
+    WalletAdapterProps,
+    WalletError,
+    WalletName,
 } from '@solana/wallet-adapter-base';
-import { type PublicKey } from '@solana/web3.js';
-import React, { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { WalletNotConnectedError, WalletNotReadyError, WalletReadyState } from '@solana/wallet-adapter-base';
+import type { PublicKey } from '@solana/web3.js';
+import type { ReactNode } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { WalletNotSelectedError } from './errors.js';
 import { WalletContext } from './useWallet.js';
 

--- a/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderBase-test.tsx
@@ -4,20 +4,16 @@
 
 'use strict';
 
-import {
-    type Adapter,
-    BaseWalletAdapter,
-    WalletError,
-    type WalletName,
-    WalletNotReadyError,
-    WalletReadyState,
-} from '@solana/wallet-adapter-base';
+import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
+import { BaseWalletAdapter, WalletError, WalletNotReadyError, WalletReadyState } from '@solana/wallet-adapter-base';
 import { PublicKey } from '@solana/web3.js';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
-import { useWallet, type WalletContextState } from '../useWallet.js';
-import { WalletProviderBase, type WalletProviderBaseProps } from '../WalletProviderBase.js';
+import type { WalletContextState } from '../useWallet.js';
+import { useWallet } from '../useWallet.js';
+import type { WalletProviderBaseProps } from '../WalletProviderBase.js';
+import { WalletProviderBase } from '../WalletProviderBase.js';
 
 type TestRefType = {
     getWalletContextState(): WalletContextState;

--- a/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderDesktop-test.tsx
@@ -4,20 +4,20 @@
 
 'use strict';
 
-import {
-    type AddressSelector,
-    type AuthorizationResultCache,
-    SolanaMobileWalletAdapter,
-} from '@solana-mobile/wallet-adapter-mobile';
-import { type Adapter, WalletError, type WalletName, WalletReadyState } from '@solana/wallet-adapter-base';
+import type { AddressSelector, AuthorizationResultCache } from '@solana-mobile/wallet-adapter-mobile';
+import { SolanaMobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile';
+import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
+import { WalletError, WalletReadyState } from '@solana/wallet-adapter-base';
 import { PublicKey } from '@solana/web3.js';
 import 'jest-localstorage-mock';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { MockWalletAdapter } from '../__mocks__/MockWalletAdapter.js';
-import { useWallet, type WalletContextState } from '../useWallet.js';
-import { WalletProvider, type WalletProviderProps } from '../WalletProvider.js';
+import type { WalletContextState } from '../useWallet.js';
+import { useWallet } from '../useWallet.js';
+import type { WalletProviderProps } from '../WalletProvider.js';
+import { WalletProvider } from '../WalletProvider.js';
 
 jest.mock('../getEnvironment.js', () => ({
     ...jest.requireActual('../getEnvironment.js'),

--- a/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
+++ b/packages/core/react/src/__tests__/WalletProviderMobile-test.tsx
@@ -4,27 +4,21 @@
 
 'use strict';
 
-import {
-    type AddressSelector,
-    type AuthorizationResultCache,
-    SolanaMobileWalletAdapter,
-    SolanaMobileWalletAdapterWalletName,
-} from '@solana-mobile/wallet-adapter-mobile';
-import {
-    type Adapter,
-    BaseWalletAdapter,
-    WalletError,
-    type WalletName,
-    WalletReadyState,
-} from '@solana/wallet-adapter-base';
-import { type Connection, PublicKey } from '@solana/web3.js';
+import type { AddressSelector, AuthorizationResultCache } from '@solana-mobile/wallet-adapter-mobile';
+import { SolanaMobileWalletAdapter, SolanaMobileWalletAdapterWalletName } from '@solana-mobile/wallet-adapter-mobile';
+import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
+import { BaseWalletAdapter, WalletError, WalletReadyState } from '@solana/wallet-adapter-base';
+import type { Connection } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import 'jest-localstorage-mock';
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { useConnection } from '../useConnection.js';
-import { useWallet, type WalletContextState } from '../useWallet.js';
-import { WalletProvider, type WalletProviderProps } from '../WalletProvider.js';
+import type { WalletContextState } from '../useWallet.js';
+import { useWallet } from '../useWallet.js';
+import type { WalletProviderProps } from '../WalletProvider.js';
+import { WalletProvider } from '../WalletProvider.js';
 
 jest.mock('../getEnvironment.js', () => ({
     ...jest.requireActual('../getEnvironment.js'),

--- a/packages/core/react/src/__tests__/getEnvironment-test.ts
+++ b/packages/core/react/src/__tests__/getEnvironment-test.ts
@@ -1,4 +1,5 @@
-import { type Adapter, WalletReadyState } from '@solana/wallet-adapter-base';
+import type { Adapter } from '@solana/wallet-adapter-base';
+import { WalletReadyState } from '@solana/wallet-adapter-base';
 import getEnvironment, { Environment } from '../getEnvironment.js';
 
 describe('getEnvironment()', () => {

--- a/packages/core/react/src/getEnvironment.ts
+++ b/packages/core/react/src/getEnvironment.ts
@@ -1,5 +1,6 @@
 import { SolanaMobileWalletAdapterWalletName } from '@solana-mobile/wallet-adapter-mobile';
-import { type Adapter, WalletReadyState } from '@solana/wallet-adapter-base';
+import type { Adapter } from '@solana/wallet-adapter-base';
+import { WalletReadyState } from '@solana/wallet-adapter-base';
 
 export enum Environment {
     DESKTOP_WEB,

--- a/packages/core/react/src/getInferredClusterFromEndpoint.ts
+++ b/packages/core/react/src/getInferredClusterFromEndpoint.ts
@@ -1,4 +1,4 @@
-import { type Cluster } from '@solana/web3.js';
+import type { Cluster } from '@solana/web3.js';
 
 export default function getInferredClusterFromEndpoint(endpoint?: string): Cluster {
     if (!endpoint) {

--- a/packages/core/react/src/useAnchorWallet.ts
+++ b/packages/core/react/src/useAnchorWallet.ts
@@ -1,4 +1,4 @@
-import { type PublicKey, type Transaction } from '@solana/web3.js';
+import type { PublicKey, Transaction } from '@solana/web3.js';
 import { useMemo } from 'react';
 import { useWallet } from './useWallet.js';
 

--- a/packages/core/react/src/useConnection.tsx
+++ b/packages/core/react/src/useConnection.tsx
@@ -1,4 +1,4 @@
-import { type Connection } from '@solana/web3.js';
+import type { Connection } from '@solana/web3.js';
 import { createContext, useContext } from 'react';
 
 export interface ConnectionContextState {

--- a/packages/core/react/src/useLocalStorage.native.ts
+++ b/packages/core/react/src/useLocalStorage.native.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { type useLocalStorage as baseUseLocalStorage } from './useLocalStorage.js';
+import type { useLocalStorage as baseUseLocalStorage } from './useLocalStorage.js';
 
 export const useLocalStorage: typeof baseUseLocalStorage = function useLocalStorage<T>(
     _key: string,

--- a/packages/core/react/src/useLocalStorage.ts
+++ b/packages/core/react/src/useLocalStorage.ts
@@ -1,4 +1,5 @@
-import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
 export function useLocalStorage<T>(key: string, defaultState: T): [T, Dispatch<SetStateAction<T>>] {
     const state = useState<T>(() => {

--- a/packages/core/react/src/useWallet.ts
+++ b/packages/core/react/src/useWallet.ts
@@ -1,13 +1,13 @@
-import {
-    type Adapter,
-    type MessageSignerWalletAdapterProps,
-    type SendTransactionOptions,
-    type SignerWalletAdapterProps,
-    type WalletAdapterProps,
-    type WalletName,
-    type WalletReadyState,
+import type {
+    Adapter,
+    MessageSignerWalletAdapterProps,
+    SendTransactionOptions,
+    SignerWalletAdapterProps,
+    WalletAdapterProps,
+    WalletName,
+    WalletReadyState,
 } from '@solana/wallet-adapter-base';
-import { type Connection, type PublicKey, type Transaction, type VersionedTransaction } from '@solana/web3.js';
+import type { Connection, PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import { createContext, useContext } from 'react';
 
 export interface Wallet {

--- a/packages/ui/ant-design/src/WalletModal.tsx
+++ b/packages/ui/ant-design/src/WalletModal.tsx
@@ -1,6 +1,7 @@
 import type { WalletName } from '@solana/wallet-adapter-base';
 import { WalletReadyState } from '@solana/wallet-adapter-base';
-import { useWallet, type Wallet } from '@solana/wallet-adapter-react';
+import type { Wallet } from '@solana/wallet-adapter-react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import type { ModalProps } from 'antd';
 import { Menu, Modal } from 'antd';
 import type { FC, MouseEvent } from 'react';

--- a/packages/ui/material-ui/src/WalletDialog.tsx
+++ b/packages/ui/material-ui/src/WalletDialog.tsx
@@ -20,7 +20,8 @@ import {
 } from '@mui/material';
 import type { WalletName } from '@solana/wallet-adapter-base';
 import { WalletReadyState } from '@solana/wallet-adapter-base';
-import { useWallet, type Wallet } from '@solana/wallet-adapter-react';
+import type { Wallet } from '@solana/wallet-adapter-react';
+import { useWallet } from '@solana/wallet-adapter-react';
 import type { FC, ReactElement, SyntheticEvent } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useWalletDialog } from './useWalletDialog.js';


### PR DESCRIPTION
In the latest version there are type errors due to mixing imports and type imports. This PR splits the imports to generate valid type definitions.

Error examples:
<img width="874" alt="Screenshot 2023-03-08 at 18 09 23" src="https://user-images.githubusercontent.com/23258994/223795479-df64e842-9531-45f7-a2eb-8bbde05d2faf.png">
<img width="966" alt="Screenshot 2023-03-08 at 18 09 48" src="https://user-images.githubusercontent.com/23258994/223795495-57e298cf-c78b-4ffa-815b-19445966a3c9.png">
