### PR TITLE
update `AnchorWallet` interface with versioned txs

### DIFF
--- a/.changeset/quiet-eagles-rhyme.md
+++ b/.changeset/quiet-eagles-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-adapter-react': patch
+---
+
+Add VersionedTransaction support to AnchorWallet interface and useAnchorWallet hook

--- a/packages/core/react/src/useAnchorWallet.ts
+++ b/packages/core/react/src/useAnchorWallet.ts
@@ -1,11 +1,11 @@
-import { type PublicKey, type Transaction } from '@solana/web3.js';
+import { type PublicKey, type Transaction, type VersionedTransaction } from '@solana/web3.js';
 import { useMemo } from 'react';
 import { useWallet } from './useWallet.js';
 
 export interface AnchorWallet {
     publicKey: PublicKey;
-    signTransaction(transaction: Transaction): Promise<Transaction>;
-    signAllTransactions(transactions: Transaction[]): Promise<Transaction[]>;
+    signTransaction<T extends Transaction | VersionedTransaction>(transaction: T): Promise<T>;
+    signAllTransactions<T extends Transaction | VersionedTransaction>(transactions: T[]): Promise<T[]>;
 }
 
 export function useAnchorWallet(): AnchorWallet | undefined {


### PR DESCRIPTION
updates the `signTransaction` and `signAllTransactions` of `AnchorWallet` to be generic over `T extends Transaction | VersionedTransaction`.