### PR TITLE
feat: Update to 2.0.0 of the Solana Mobile Wallet adapter

### DIFF
--- a/.changeset/pretty-carpets-laugh.md
+++ b/.changeset/pretty-carpets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@solana/wallet-adapter-react": patch
+---
+
+Update to 2.0.0 of the Solana Mobile Wallet adapter. This fixes a bug where the app's `AppIdentity` would not be forwarded to the wallet when `reauthorize` was called, as demanded by the specification.

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -37,7 +37,7 @@
         "react": "*"
     },
     "dependencies": {
-        "@solana-mobile/wallet-adapter-mobile": "^0.9.9",
+        "@solana-mobile/wallet-adapter-mobile": "^2.0.0",
         "@solana/wallet-adapter-base": "workspace:^",
         "@solana/wallet-standard-wallet-adapter-react": "^1.0.1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
 
   packages/core/react:
     specifiers:
-      '@solana-mobile/wallet-adapter-mobile': ^0.9.9
+      '@solana-mobile/wallet-adapter-mobile': ^2.0.0
       '@solana/wallet-adapter-base': workspace:^
       '@solana/wallet-standard-wallet-adapter-react': ^1.0.1
       '@solana/web3.js': ^1.73.2
@@ -83,7 +83,7 @@ importers:
       shx: ^0.3.4
       ts-jest: ^28.0.8
     dependencies:
-      '@solana-mobile/wallet-adapter-mobile': 0.9.9_4t6oakxqfhcjx4iphnufztw5py
+      '@solana-mobile/wallet-adapter-mobile': 2.0.0_4t6oakxqfhcjx4iphnufztw5py
       '@solana/wallet-adapter-base': link:../base
       '@solana/wallet-standard-wallet-adapter-react': 1.0.1_doaatyv7cjn6rdxet3etxjaxca
     devDependencies:
@@ -97,7 +97,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       shx: 0.3.4
-      ts-jest: 28.0.8_gqlcbixuhssnf7bqjgu77ulzoa
+      ts-jest: 28.0.8_lawjxbsqt7dx272n2gqzylye6u
 
   packages/starter/create-react-app-starter:
     specifiers:
@@ -132,7 +132,7 @@ importers:
       react: 18.2.0
       react-app-rewired: 2.2.1_react-scripts@5.0.1
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wcpkporqqb2vuos4u4geg4sfbe
+      react-scripts: 5.0.1_ogtxzlim7vdxyw5k3edjd244ie
       web-vitals: 2.1.4
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
@@ -933,12 +933,12 @@ importers:
       '@walletconnect/types': ^2.4.5
       shx: ^0.3.4
     dependencies:
-      '@jnwng/walletconnect-solana': 0.1.5_w3y6bqucitmoqiffnei6liljqq
+      '@jnwng/walletconnect-solana': 0.1.5_gihbfnaog32bltdblujsz4ypla
       '@solana/wallet-adapter-base': link:../../core/base
     devDependencies:
       '@solana/web3.js': 1.73.2
       '@types/pino': 6.3.12
-      '@walletconnect/types': 2.4.5_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/types': 2.4.5_yacyvs23jolzrmic77hkivodau
       shx: 0.3.4
 
   packages/wallets/wallets:
@@ -3532,15 +3532,15 @@ packages:
       chalk: 4.1.2
     dev: false
 
-  /@jnwng/walletconnect-solana/0.1.5_w3y6bqucitmoqiffnei6liljqq:
+  /@jnwng/walletconnect-solana/0.1.5_gihbfnaog32bltdblujsz4ypla:
     resolution: {integrity: sha512-n8YLfF6NIVOqn+YeJEFRaZbbeNTGXL+VPBl+hqMpxLH+Fp+qgdm4CYH+ULH/OSszL2DBO1j+hB/XFDPiswCNeA==}
     peerDependencies:
       '@solana/web3.js': ^1.52.0
     dependencies:
       '@solana/web3.js': 1.73.2
       '@walletconnect/qrcode-modal': 1.8.0
-      '@walletconnect/sign-client': 2.4.5_tncu2ai53lzgmizdedur7lbibe
-      '@walletconnect/utils': 2.4.5_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/sign-client': 2.4.5_yacyvs23jolzrmic77hkivodau
+      '@walletconnect/utils': 2.4.5_yacyvs23jolzrmic77hkivodau
       bs58: 5.0.0
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -4959,7 +4959,7 @@ packages:
       react-native: ^0.0.0-0 || 0.60 - 0.71 || 1000.0.0
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.71.3_gkfvc6x5loptk33ura547aycvm
+      react-native: 0.71.3_raab37p3ikkajcivlo24zcd7ie
     dev: false
 
   /@react-native-community/cli-clean/10.1.1:
@@ -5078,7 +5078,7 @@ packages:
       - encoding
     dev: false
 
-  /@react-native-community/cli-plugin-metro/10.2.0:
+  /@react-native-community/cli-plugin-metro/10.2.0_@babel+core@7.21.0:
     resolution: {integrity: sha512-9eiJrKYuauEDkQLCrjJUh7tS9T0oaMQqVUSSSuyDG6du7HQcfaR4mSf21wK75jvhKiwcQLpsFmMdctAb+0v+Cg==}
     dependencies:
       '@react-native-community/cli-server-api': 10.1.1
@@ -5088,11 +5088,12 @@ packages:
       metro: 0.73.8
       metro-config: 0.73.8
       metro-core: 0.73.8
-      metro-react-native-babel-transformer: 0.73.8
+      metro-react-native-babel-transformer: 0.73.8_@babel+core@7.21.0
       metro-resolver: 0.73.8
       metro-runtime: 0.73.8
       readline: 1.3.0
     transitivePeerDependencies:
+      - '@babel/core'
       - bufferutil
       - encoding
       - supports-color
@@ -5140,7 +5141,7 @@ packages:
       joi: 17.8.3
     dev: false
 
-  /@react-native-community/cli/10.1.3:
+  /@react-native-community/cli/10.1.3_@babel+core@7.21.0:
     resolution: {integrity: sha512-kzh6bYLGN1q1q0IiczKSP1LTrovFeVzppYRTKohPI9VdyZwp7b5JOgaQMB/Ijtwm3MxBDrZgV9AveH/eUmUcKQ==}
     engines: {node: '>=14'}
     hasBin: true
@@ -5150,7 +5151,7 @@ packages:
       '@react-native-community/cli-debugger-ui': 10.0.0
       '@react-native-community/cli-doctor': 10.2.0
       '@react-native-community/cli-hermes': 10.2.0
-      '@react-native-community/cli-plugin-metro': 10.2.0
+      '@react-native-community/cli-plugin-metro': 10.2.0_@babel+core@7.21.0
       '@react-native-community/cli-server-api': 10.1.1
       '@react-native-community/cli-tools': 10.1.1
       '@react-native-community/cli-types': 10.0.0
@@ -5163,6 +5164,7 @@ packages:
       prompts: 2.4.2
       semver: 6.3.0
     transitivePeerDependencies:
+      - '@babel/core'
       - bufferutil
       - encoding
       - supports-color
@@ -5292,12 +5294,12 @@ packages:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: false
 
-  /@solana-mobile/mobile-wallet-adapter-protocol-web3js/0.9.9_4t6oakxqfhcjx4iphnufztw5py:
-    resolution: {integrity: sha512-JzlNjZ/Uog56iP/z8QtNrIOgQwmaoicpr9768s0QVF4xuvNbyWHOaDtsngzNneNTMfLSgd0tueboKUrkvto/Wg==}
+  /@solana-mobile/mobile-wallet-adapter-protocol-web3js/2.0.0_4t6oakxqfhcjx4iphnufztw5py:
+    resolution: {integrity: sha512-cMADp/UIAN42QJVCM1oyj1wFM/9DTZNIa5z5eHXUXBksw/bNv2fWkiO+4ZUoQj1P4UoMoZJUBx9+qMVl18sPOA==}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': 0.9.9_react-native@0.71.3
+      '@solana-mobile/mobile-wallet-adapter-protocol': 2.0.0_react-native@0.71.3
       '@solana/web3.js': 1.73.2
       bs58: 5.0.0
       js-base64: 3.7.5
@@ -5305,21 +5307,21 @@ packages:
       - react-native
     dev: false
 
-  /@solana-mobile/mobile-wallet-adapter-protocol/0.9.9_react-native@0.71.3:
-    resolution: {integrity: sha512-Jxd3O3txeUiAXLIo6YfWhTs7UTVMlnIgz/xgdYmf99TSE4IaUhWGEVC2/OcOA7eAA85y0/XItU5OhHhXSPva8g==}
+  /@solana-mobile/mobile-wallet-adapter-protocol/2.0.0_react-native@0.71.3:
+    resolution: {integrity: sha512-mLK9B/AQgOxzbdRoOMH3G5wB5akWgGSBoVqIZ/6iDWY37uu/CuyX4lTwRyoRlOb8Cxs/tDwiovIGobkti2qF/w==}
     peerDependencies:
       react-native: '>0.69'
     dependencies:
-      react-native: 0.71.3_gkfvc6x5loptk33ura547aycvm
+      react-native: 0.71.3_raab37p3ikkajcivlo24zcd7ie
     dev: false
 
-  /@solana-mobile/wallet-adapter-mobile/0.9.9_4t6oakxqfhcjx4iphnufztw5py:
-    resolution: {integrity: sha512-nmxTEbKgkuI37zMpI3GWWn6DvAd/lgl6GF1lGbYSObXyZDun0bfCIQ8rBVEcvwZLyekp+i/nLW8JdSccN4i3zw==}
+  /@solana-mobile/wallet-adapter-mobile/2.0.0_4t6oakxqfhcjx4iphnufztw5py:
+    resolution: {integrity: sha512-q/m0X+LUhoSYBUaQsw+9YhttbokA5+klrC2euLhbDu+Wy/n9hL4NXNvw7291bzVvNXVh9ovBi7DjoCdcfPXRWA==}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
       '@react-native-async-storage/async-storage': 1.17.11_react-native@0.71.3
-      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 0.9.9_4t6oakxqfhcjx4iphnufztw5py
+      '@solana-mobile/mobile-wallet-adapter-protocol-web3js': 2.0.0_4t6oakxqfhcjx4iphnufztw5py
       '@solana/wallet-adapter-base': link:packages/core/base
       '@solana/web3.js': 1.73.2
       js-base64: 3.7.5
@@ -6487,10 +6489,10 @@ packages:
       detect-browser: 5.2.0
     dev: false
 
-  /@walletconnect/core/2.4.5_tncu2ai53lzgmizdedur7lbibe:
+  /@walletconnect/core/2.4.5_yacyvs23jolzrmic77hkivodau:
     resolution: {integrity: sha512-xN0XWupUdHf15rEvATen2r1NNs81RPX3s2vO0kopnfmNGBkXPkPsF/VFbWpcsYVSo1189H+7prX7IM76TdxclQ==}
     dependencies:
-      '@walletconnect/heartbeat': 1.2.0_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/heartbeat': 1.2.0_yacyvs23jolzrmic77hkivodau
       '@walletconnect/jsonrpc-provider': 1.0.8
       '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/jsonrpc-ws-connection': 1.0.9
@@ -6500,8 +6502,8 @@ packages:
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.5_tncu2ai53lzgmizdedur7lbibe
-      '@walletconnect/utils': 2.4.5_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/types': 2.4.5_yacyvs23jolzrmic77hkivodau
+      '@walletconnect/utils': 2.4.5_yacyvs23jolzrmic77hkivodau
       events: 3.3.0
       lodash.isequal: 4.5.0
       pino: 7.11.0
@@ -6529,14 +6531,14 @@ packages:
       keyvaluestorage-interface: 1.0.0
       tslib: 1.14.1
 
-  /@walletconnect/heartbeat/1.2.0_tncu2ai53lzgmizdedur7lbibe:
+  /@walletconnect/heartbeat/1.2.0_yacyvs23jolzrmic77hkivodau:
     resolution: {integrity: sha512-0vbzTa/ARrpmMmOD+bQMxPvFYKtOLQZObgZakrYr0aODiMOO71CmPVNV2eAqXnw9rMmcP+z91OybLeIFlwTjjA==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/time': 1.0.2
       chai: 4.3.7
       mocha: 10.2.0
-      ts-node: 10.9.1_tncu2ai53lzgmizdedur7lbibe
+      ts-node: 10.9.1_yacyvs23jolzrmic77hkivodau
       tslib: 1.14.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -6644,18 +6646,18 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@walletconnect/sign-client/2.4.5_tncu2ai53lzgmizdedur7lbibe:
+  /@walletconnect/sign-client/2.4.5_yacyvs23jolzrmic77hkivodau:
     resolution: {integrity: sha512-8CCiXBkp8crHW+dix28l8ZzvLqO2LK1UR2akP3jxPidNFXwB+N+wLJpE0Ey8OyXDbM7T3ZpNcQvnn7bdlOBkUA==}
     dependencies:
-      '@walletconnect/core': 2.4.5_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/core': 2.4.5_yacyvs23jolzrmic77hkivodau
       '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.0_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/heartbeat': 1.2.0_yacyvs23jolzrmic77hkivodau
       '@walletconnect/jsonrpc-provider': 1.0.8
       '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/logger': 2.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.5_tncu2ai53lzgmizdedur7lbibe
-      '@walletconnect/utils': 2.4.5_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/types': 2.4.5_yacyvs23jolzrmic77hkivodau
+      '@walletconnect/utils': 2.4.5_yacyvs23jolzrmic77hkivodau
       events: 3.3.0
       pino: 7.11.0
     transitivePeerDependencies:
@@ -6679,11 +6681,11 @@ packages:
     deprecated: 'WalletConnect''s v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/'
     dev: false
 
-  /@walletconnect/types/2.4.5_tncu2ai53lzgmizdedur7lbibe:
+  /@walletconnect/types/2.4.5_yacyvs23jolzrmic77hkivodau:
     resolution: {integrity: sha512-/MNubZ0K39DvZfA4kL1nZNpvRUJAWZwNq8ySfCYR/EMQMGfAemRi/Ckv1wNo6jGtDMRLuTxT5px2xJUBOBAEPQ==}
     dependencies:
       '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.0_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/heartbeat': 1.2.0_yacyvs23jolzrmic77hkivodau
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/keyvaluestorage': 1.0.2
       '@walletconnect/logger': 2.0.1
@@ -6696,7 +6698,7 @@ packages:
       - lokijs
       - typescript
 
-  /@walletconnect/utils/2.4.5_tncu2ai53lzgmizdedur7lbibe:
+  /@walletconnect/utils/2.4.5_yacyvs23jolzrmic77hkivodau:
     resolution: {integrity: sha512-TehHlHZL8KLWeVNyfMF+GCNcPOO0z+wiiFDVmVuS8GJWWi4xJOcLJAD8w0KMGc6K4n74cuw5yXiRpBpJN2FIlQ==}
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
@@ -6708,7 +6710,7 @@ packages:
       '@walletconnect/relay-api': 1.0.8
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.5_tncu2ai53lzgmizdedur7lbibe
+      '@walletconnect/types': 2.4.5_yacyvs23jolzrmic77hkivodau
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -6952,8 +6954,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.12.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -9576,7 +9580,7 @@ packages:
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 2.7.1_2empl2qtc2ugxu3jki5uzfwixa
-      eslint-plugin-import: 2.27.5_iflsocsixkjayhf73a44qi5zcq
+      eslint-plugin-import: 2.27.5_eslint@8.22.0
       eslint-plugin-jsx-a11y: 6.7.1_eslint@8.22.0
       eslint-plugin-react: 7.32.2_eslint@8.22.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.22.0
@@ -9648,11 +9652,39 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 8.22.0
-      eslint-plugin-import: 2.27.5_iflsocsixkjayhf73a44qi5zcq
+      eslint-plugin-import: 2.27.5_eslint@8.22.0
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils/2.7.4_i4aqrmrx6baqjrxwklfdrhbp7a:
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      debug: 3.2.7
+      eslint: 8.22.0
+      eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9686,36 +9718,6 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.4_vmljjhtpzo34llgrc245teqzku:
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
-      debug: 3.2.7
-      eslint: 8.22.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 2.7.1_2empl2qtc2ugxu3jki5uzfwixa
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-plugin-flowtype/8.0.3_muluhsdfgldhzmc64lu5hegcca:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
@@ -9731,7 +9733,7 @@ packages:
       string-natural-compare: 3.0.1
     dev: false
 
-  /eslint-plugin-import/2.27.5_iflsocsixkjayhf73a44qi5zcq:
+  /eslint-plugin-import/2.27.5_eslint@8.22.0:
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9741,7 +9743,6 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.53.0_4rv7y5c6xz3vfxwhbrcxxi73bq
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -9749,7 +9750,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.22.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4_vmljjhtpzo34llgrc245teqzku
+      eslint-module-utils: 2.7.4_i4aqrmrx6baqjrxwklfdrhbp7a
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -11772,13 +11773,13 @@ packages:
       '@types/connect': 3.4.35
       '@types/node': 12.20.55
       '@types/ws': 7.4.7
+      JSONStream: 1.3.5
       commander: 2.20.3
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
       isomorphic-ws: 4.0.1_ws@7.5.9
       json-stringify-safe: 5.0.1
-      JSONStream: 1.3.5
       lodash: 4.17.21
       uuid: 8.3.2
       ws: 7.5.9
@@ -13671,8 +13672,10 @@ packages:
       uglify-es: 3.3.9
     dev: false
 
-  /metro-react-native-babel-preset/0.73.7:
+  /metro-react-native-babel-preset/0.73.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-RKcmRZREjJCzHKP+JhC9QTCohkeb3xa/DtqHU14U5KWzJHdC0mMrkTZYNXhV0cryxsaVKVEw5873KhbZyZHMVw==}
+    peerDependencies:
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.21.0
       '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.21.0
@@ -13716,8 +13719,10 @@ packages:
       - supports-color
     dev: false
 
-  /metro-react-native-babel-preset/0.73.8:
+  /metro-react-native-babel-preset/0.73.8_@babel+core@7.21.0:
     resolution: {integrity: sha512-spNrcQJTbQntEIqJnCA6yL4S+dzV9fXCk7U+Rm7yJasZ4o4Frn7jP23isu7FlZIp1Azx1+6SbP7SgQM+IP5JgQ==}
+    peerDependencies:
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.21.0
       '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.21.0
@@ -13761,28 +13766,32 @@ packages:
       - supports-color
     dev: false
 
-  /metro-react-native-babel-transformer/0.73.7:
+  /metro-react-native-babel-transformer/0.73.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-73HW8betjX+VPm3iqsMBe8F/F2Tt+hONO6YJwcF7FonTqQYW1oTz0dOp0dClZGfHUXxpJBz6Vuo7J6TpdzDD+w==}
+    peerDependencies:
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.21.0
       babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.73.7
-      metro-react-native-babel-preset: 0.73.7
+      metro-react-native-babel-preset: 0.73.7_@babel+core@7.21.0
       metro-source-map: 0.73.7
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /metro-react-native-babel-transformer/0.73.8:
+  /metro-react-native-babel-transformer/0.73.8_@babel+core@7.21.0:
     resolution: {integrity: sha512-oH/LCCJPauteAE28c0KJAiSrkV+1VJbU0PwA9UwaWnle+qevs/clpKQ8LrIr33YbBj4CiI1kFoVRuNRt5h4NFg==}
+    peerDependencies:
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.21.0
       babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.73.8
-      metro-react-native-babel-preset: 0.73.8
+      metro-react-native-babel-preset: 0.73.8_@babel+core@7.21.0
       metro-source-map: 0.73.8
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -13940,7 +13949,7 @@ packages:
       metro-inspector-proxy: 0.73.8
       metro-minify-terser: 0.73.8
       metro-minify-uglify: 0.73.8
-      metro-react-native-babel-preset: 0.73.8
+      metro-react-native-babel-preset: 0.73.8_@babel+core@7.21.0
       metro-resolver: 0.73.8
       metro-runtime: 0.73.8
       metro-source-map: 0.73.8
@@ -16596,13 +16605,19 @@ packages:
     peerDependencies:
       react-scripts: '>=2.1.3'
     dependencies:
-      react-scripts: 5.0.1_wcpkporqqb2vuos4u4geg4sfbe
+      react-scripts: 5.0.1_ogtxzlim7vdxyw5k3edjd244ie
       semver: 5.7.1
     dev: false
 
   /react-dev-utils/12.0.1_uxrk33lftfxfwytryt6oeiav4q:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.2
@@ -16628,12 +16643,12 @@ packages:
       shell-quote: 1.8.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      typescript: 4.7.4
+      webpack: 5.75.0
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-devtools-core/4.27.2:
@@ -16719,7 +16734,7 @@ packages:
     resolution: {integrity: sha512-7S3pAuPaQJlhax6EZ4JMsDNpj05TfuzX9gPgWLrFfAIWIFLuJ6aDQYAZy2TEI9QJALPoWrj8LWaqP/DGYh14pw==}
     dev: false
 
-  /react-native/0.71.3_gkfvc6x5loptk33ura547aycvm:
+  /react-native/0.71.3_raab37p3ikkajcivlo24zcd7ie:
     resolution: {integrity: sha512-RYJXCcQGa4NTfKiPgl92eRDUuQ6JGDnHqFEzRwJSqEx9lWvlvRRIebstJfurzPDKLQWQrvITR7aI7e09E25mLw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -16727,7 +16742,7 @@ packages:
       react: 18.2.0
     dependencies:
       '@jest/create-cache-key-function': 29.4.3
-      '@react-native-community/cli': 10.1.3
+      '@react-native-community/cli': 10.1.3_@babel+core@7.21.0
       '@react-native-community/cli-platform-android': 10.1.3
       '@react-native-community/cli-platform-ios': 10.1.1
       '@react-native/assets': 1.0.0
@@ -16742,7 +16757,7 @@ packages:
       jest-environment-node: 29.4.3
       jsc-android: 250231.0.0
       memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.73.7
+      metro-react-native-babel-transformer: 0.73.7_@babel+core@7.21.0
       metro-runtime: 0.73.7
       metro-source-map: 0.73.7
       mkdirp: 0.5.6
@@ -16762,6 +16777,7 @@ packages:
       whatwg-fetch: 3.6.2
       ws: 6.2.2
     transitivePeerDependencies:
+      - '@babel/core'
       - '@babel/preset-env'
       - bufferutil
       - encoding
@@ -16797,11 +16813,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-scripts/5.0.1_wcpkporqqb2vuos4u4geg4sfbe:
+  /react-scripts/5.0.1_ogtxzlim7vdxyw5k3edjd244ie:
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:
+      eslint: '*'
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -16850,7 +16867,7 @@ packages:
       semver: 7.3.8
       source-map-loader: 3.0.2_webpack@5.75.0
       style-loader: 3.3.1_webpack@5.75.0
-      tailwindcss: 3.2.7
+      tailwindcss: 3.2.7_postcss@8.4.21
       terser-webpack-plugin: 5.3.6_webpack@5.75.0
       typescript: 4.7.4
       webpack: 5.75.0
@@ -17436,7 +17453,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.12.0
       ajv-keywords: 5.1.0_ajv@8.12.0
     dev: false
 
@@ -18288,10 +18305,12 @@ packages:
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  /tailwindcss/3.2.7:
+  /tailwindcss/3.2.7_postcss@8.4.21:
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -18550,7 +18569,7 @@ packages:
     resolution: {integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==}
     dev: false
 
-  /ts-jest/28.0.8_gqlcbixuhssnf7bqjgu77ulzoa:
+  /ts-jest/28.0.8_lawjxbsqt7dx272n2gqzylye6u:
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -18580,11 +18599,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 4.9.5
+      typescript: 4.7.4
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node/10.9.1_tncu2ai53lzgmizdedur7lbibe:
+  /ts-node/10.9.1_yacyvs23jolzrmic77hkivodau:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -18610,7 +18629,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 4.7.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -18809,6 +18828,7 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: false
 
   /uglify-es/3.3.9:
     resolution: {integrity: sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==}


### PR DESCRIPTION
This fixes a bug where the app's `AppIdentity` would not be forwarded to the wallet when `reauthorize` was called, as demanded by the specification.

See https://github.com/solana-mobile/mobile-wallet-adapter/pull/416 for more.