### PR TITLE
Export DEFAULT_CONTEXT from useWallet

### DIFF
--- a/packages/core/react/src/useWallet.ts
+++ b/packages/core/react/src/useWallet.ts
@@ -36,7 +36,7 @@ export interface WalletContextState {
 
 const EMPTY_ARRAY: ReadonlyArray<never> = [];
 
-const DEFAULT_CONTEXT = {
+export const DEFAULT_CONTEXT = {
     autoConnect: false,
     connecting: false,
     connected: false,


### PR DESCRIPTION
Hi,

I have a case where I handle and share the wallet rather via my own state store, instead of using useWallet in multiple components. In order to initialize the store it would be helpful to have access to DEFAULT_CONTEXT.
Maybe there are other potential cases where a wallet needs a default, before useWallet is available.

Thought maybe you find this a good idea, too. But I'm also not offended if you find my case too edgy, since most of the time useWallet should do the job.