### PR TITLE
Fix next warnings when building starter project

### DIFF
--- a/.changeset/thick-tomatoes-pretend.md
+++ b/.changeset/thick-tomatoes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-adapter-example': minor
+---
+
+Fix next.js warnings when building starter project

--- a/.changeset/thick-tomatoes-pretend.md
+++ b/.changeset/thick-tomatoes-pretend.md
@@ -1,5 +1,5 @@
 ---
-'@solana/wallet-adapter-example': minor
+'@solana/wallet-adapter-example': patch
 ---
 
 Fix next.js warnings when building starter project

--- a/packages/starter/example/next.config.js
+++ b/packages/starter/example/next.config.js
@@ -1,24 +1,23 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const plugins = require('next-compose-plugins');
-const antdLess = require('next-plugin-antd-less');
+const withAntdLess = require('next-plugin-antd-less');
 const { PHASE_PRODUCTION_BUILD } = require('next/constants');
 
-module.exports = function (phase, ...args) {
-    return plugins(
-        [
-            [
-                antdLess,
-                {
-                    modifyVars: {
-                        '@background': '#303030',
-                        '@primary-color': '#512da8',
-                    },
-                },
-            ],
-        ],
-        {
-            reactStrictMode: true,
-            basePath: phase === PHASE_PRODUCTION_BUILD ? '/wallet-adapter/example' : '',
-        }
-    )(phase, ...args);
+const COLORS = {
+    GREY: '#303030',
+    PURPLE: '#512da8',
+};
+
+module.exports = function (phase, { defaultConfig }) {
+    // See https://github.com/SolidZORO/next-plugin-antd-less
+    const config = withAntdLess({
+        // Note this produces an unnecessary warning:
+        // 'The root value has an unexpected property, modifyVars'
+        // See https://github.com/SolidZORO/next-plugin-antd-less/issues/105
+        modifyVars: {
+            '@background': COLORS.GREY,
+            '@primary-color': COLORS.PURPLE,
+        },
+        basePath: phase === PHASE_PRODUCTION_BUILD ? '/wallet-adapter/example' : '',
+    });
+
+    return config;
 };

--- a/packages/starter/example/package.json
+++ b/packages/starter/example/package.json
@@ -61,7 +61,6 @@
         "@types/react-dom": "^18.0.11",
         "eslint": "8.22.0",
         "eslint-config-next": "^12.3.4",
-        "next-compose-plugins": "^2.2.1",
         "next-plugin-antd-less": "^1.8.0",
         "prettier": "^2.8.4",
         "shx": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,9 +282,6 @@ importers:
       eslint-config-next:
         specifier: ^12.3.4
         version: 12.3.4(eslint@8.22.0)(typescript@4.7.4)
-      next-compose-plugins:
-        specifier: ^2.2.1
-        version: 2.2.1
       next-plugin-antd-less:
         specifier: ^1.8.0
         version: 1.8.0(webpack@5.77.0)
@@ -14313,10 +14310,6 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  /next-compose-plugins@2.2.1:
-    resolution: {integrity: sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==}
-    dev: true
 
   /next-plugin-antd-less@1.8.0(webpack@5.77.0):
     resolution: {integrity: sha512-LwJAoXVvWfDqsSTlRof7EWKxlFlxgLD/6DkwUX6jnqrJMxH4KAEo3U09w4y3hn1fMh0LIRUWYLdnc1HTgDyh/A==}


### PR DESCRIPTION
Fix most next warnings when building starter project:

 - `next-compose-plugins` is [no longer maintained](https://www.npmjs.com/package/next-compose-plugins) so get along without it.
 - There's one remaining error re: `modifyVars` but add a link to the upstream issue.
 - Use variables for the colors rather than magic numbers.
