### PR TITLE
Change disconnect button disable logic to fix for MWA

### DIFF
--- a/packages/ui/ant-design/src/WalletDisconnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletDisconnectButton.tsx
@@ -14,7 +14,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({
     onClick,
     ...props
 }) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
+    const { wallet, connected, disconnect, disconnecting } = useWallet();
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
         (event) => {
@@ -38,7 +38,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({
     return (
         <Button
             onClick={handleClick}
-            disabled={disabled || !wallet}
+            disabled={disabled || !connected}
             icon={<WalletIcon wallet={wallet} />}
             type={type}
             size={size}

--- a/packages/ui/material-ui/src/WalletDisconnectButton.tsx
+++ b/packages/ui/material-ui/src/WalletDisconnectButton.tsx
@@ -14,7 +14,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({
     onClick,
     ...props
 }) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
+    const { wallet, connected, disconnect, disconnecting } = useWallet();
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
         (event) => {
@@ -41,7 +41,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({
             variant={variant}
             type={type}
             onClick={handleClick}
-            disabled={disabled || !wallet}
+            disabled={disabled || !connected}
             startIcon={<WalletIcon wallet={wallet} />}
             {...props}
         >

--- a/packages/ui/react-ui/src/WalletDisconnectButton.tsx
+++ b/packages/ui/react-ui/src/WalletDisconnectButton.tsx
@@ -6,7 +6,7 @@ import { Button } from './Button.js';
 import { WalletIcon } from './WalletIcon.js';
 
 export const WalletDisconnectButton: FC<ButtonProps> = ({ children, disabled, onClick, ...props }) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
+    const { wallet, connected, disconnect, disconnecting } = useWallet();
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
         (event) => {
@@ -27,7 +27,7 @@ export const WalletDisconnectButton: FC<ButtonProps> = ({ children, disabled, on
     return (
         <Button
             className="wallet-adapter-button-trigger"
-            disabled={disabled || !wallet}
+            disabled={disabled || !connected}
             startIcon={wallet ? <WalletIcon wallet={wallet} /> : undefined}
             onClick={handleClick}
             {...props}


### PR DESCRIPTION
Instead of using wallet use connected, which also works for MWA

Previously we used `!wallet`, but `wallet` is defined in Android with MWA. This PR changes to use `!connected` so that the disconnect button is correctly disabled on Android when no wallet has been connected yet.

Before (current https://solana-labs.github.io/wallet-adapter/example/ on Android):
![Screenshot_2023-04-21-11-12-31-19_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/1711350/233612998-8409586a-9e08-4d7e-9a70-ecc5ec90d6d6.jpg)

After:
![Screenshot_2023-04-21-11-12-10-92_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/1711350/233613082-d71836f5-67d0-43fe-a52d-67742853ed30.jpg)