### PR TITLE
feat: implement the starter UI atop the new `useWalletState` hook

### DIFF
--- a/packages/core/react/README.md
+++ b/packages/core/react/README.md
@@ -1,5 +1,85 @@
 # `@solana/wallet-adapter-react`
 
-<!-- @TODO -->
+## Creating a custom connect button
 
-Coming soon.
+The `useWalletButton()` hook returns the current state of the your web application's wallet connection.
+
+### States
+
+-   `no-wallet` \
+    In this state you are neither connected nor is there a wallet selected. Allow your users to select from the list of `wallets`, then call `onSelectWallet()` with the name of the wallet they chose.
+-   `disconnected` \
+    This state implies that there is a wallet selected, but that your app is not connected to it. Render a connect button that calls `onConnect()` when clicked. At any time you can read from the list of `wallets` and call `onSelectWallet()` to change wallets.
+-   `disconnecting` \
+    When in this state, the last-connected wallet is in mid-disconnection.
+-   `connected` \
+    In this state, you have access to the connected `publicKey` and an `onDisconnect()` method that you can call to disconnect from the wallet. At any time you can read from the list of `wallets` and call `onSelectWallet()` to change wallets.
+-   `connecting` \
+    When in this state, the wallet is in mid-connection.
+
+### Example
+
+```ts
+function CustomConnectButton() {
+    const [walletModalState, setWalletModalState] = useState<Readonly<{
+        onSelectWallet(walletName: WalletName): void;
+        wallets: Wallet[];
+    }> | null>(null);
+    const walletButtonState = useWalletButton();
+    const { walletState } = walletButtonState;
+    let label;
+    switch (walletState) {
+        case 'connected':
+            label = 'Disconnect';
+            break;
+        case 'connecting':
+            label = 'Connecting';
+            break;
+        case 'disconnected':
+            label = 'Connect';
+            break;
+        case 'disconnecting':
+            label = 'Disconnecting';
+            break;
+        case 'no-wallet':
+            label = 'Select Wallet';
+            break;
+    }
+    const handleClick = useCallback(() => {
+        switch (walletState) {
+            case 'connected':
+                return walletButtonState.onDisconnect();
+            case 'disconnected':
+                return walletButtonState.onConnect();
+            case 'connecting':
+            case 'disconnecting':
+                break;
+            case 'no-wallet':
+                setWalletModalState(walletButtonState);
+                break;
+        }
+    }, [walletButtonState, walletState]);
+    return (
+        <>
+            <button disabled={walletState === 'connecting' || walletState === 'disconnecting'} onClick={handleClick}>
+                {label}
+            </button>
+            {walletModalState ? (
+                <Modal>
+                    {walletModalState.wallets.map((wallet) => (
+                        <button
+                            key={wallet.adapter.name}
+                            onClick={() => {
+                                walletModalState.onSelectWallet(wallet.adapter.name);
+                                setWalletModalState(null);
+                            }}
+                        >
+                            {wallet.adapter.name}
+                        </button>
+                    ))}
+                </Modal>
+            ) : null}
+        </>
+    );
+}
+```

--- a/packages/core/react/src/index.ts
+++ b/packages/core/react/src/index.ts
@@ -4,4 +4,5 @@ export * from './useAnchorWallet.js';
 export * from './useConnection.js';
 export * from './useLocalStorage.js';
 export * from './useWallet.js';
+export * from './useWalletButton.js';
 export * from './WalletProvider.js';

--- a/packages/core/react/src/useWalletButton.ts
+++ b/packages/core/react/src/useWalletButton.ts
@@ -1,0 +1,107 @@
+import type { WalletName } from '@solana/wallet-adapter-base';
+import type { PublicKey } from '@solana/web3.js';
+import { useMemo } from 'react';
+import type { Wallet } from './useWallet.js';
+import { useWallet } from './useWallet.js';
+
+type WalletButtonState = Readonly<
+    | {
+          onDisconnect: () => void;
+          onSelectWallet: (walletName: WalletName | null) => void;
+          publicKey: PublicKey;
+          wallet: Wallet;
+          wallets: Wallet[];
+          walletState: 'connected';
+      }
+    | { wallet: Wallet; walletState: 'connecting' }
+    | {
+          onConnect: () => void;
+          onSelectWallet: (walletName: WalletName | null) => void;
+          wallet: Wallet;
+          wallets: Wallet[];
+          walletState: 'disconnected';
+      }
+    | { wallet: Wallet; walletState: 'disconnecting' }
+    | { onSelectWallet: (walletName: WalletName) => void; wallets: Wallet[]; walletState: 'no-wallet' }
+>;
+
+function invariant<T>(condition: T, message?: string): asserts condition is NonNullable<T> {
+    if (!condition) {
+        throw new Error(`invariant violation${message ? ': ' + message : ''}`);
+    }
+}
+
+export function useWalletButton(): WalletButtonState {
+    const { connect, connected, connecting, disconnecting, disconnect, publicKey, select, wallet, wallets } =
+        useWallet();
+    return useMemo<WalletButtonState>(() => {
+        let state: WalletButtonState['walletState'];
+        if (connected) {
+            state = 'connected';
+        } else if (connecting) {
+            state = 'connecting';
+        } else if (disconnecting) {
+            state = 'disconnecting';
+        } else {
+            state = 'disconnected';
+        }
+        switch (state) {
+            case 'connected':
+                invariant(publicKey, `Expected a public key while in the \`${state}\` state`);
+                invariant(wallet, `Expected a selected wallet while in the \`${state}\` state`);
+                return {
+                    onDisconnect() {
+                        disconnect().catch(() => {
+                            // Silently catch because any errors are caught by the context `onError` handler
+                        });
+                    },
+                    onSelectWallet(walletName: WalletName | null) {
+                        select(walletName);
+                    },
+                    publicKey,
+                    wallet,
+                    wallets,
+                    walletState: 'connected',
+                };
+            case 'connecting': {
+                invariant(wallet, `Expected a selected wallet while in the \`${state}\` state`);
+                return {
+                    wallet,
+                    walletState: 'connecting',
+                };
+            }
+            case 'disconnected': {
+                if (wallet) {
+                    return {
+                        onConnect() {
+                            connect().catch(() => {
+                                // Silently catch because any errors are caught by the context `onError` handler
+                            });
+                        },
+                        onSelectWallet(walletName: WalletName | null) {
+                            select(walletName);
+                        },
+                        wallet,
+                        wallets,
+                        walletState: 'disconnected',
+                    };
+                } else {
+                    return {
+                        onSelectWallet(walletName: WalletName) {
+                            select(walletName);
+                        },
+                        wallets,
+                        walletState: 'no-wallet',
+                    };
+                }
+            }
+            case 'disconnecting': {
+                invariant(wallet, `Expected a selected wallet while in the \`${state}\` state`);
+                return {
+                    wallet,
+                    walletState: 'disconnecting',
+                };
+            }
+        }
+    }, [connect, connected, connecting, disconnect, disconnecting, publicKey, select, wallet, wallets]);
+}

--- a/packages/ui/ant-design/src/WalletButonBase.tsx
+++ b/packages/ui/ant-design/src/WalletButonBase.tsx
@@ -1,0 +1,28 @@
+import type { Wallet } from '@solana/wallet-adapter-react';
+import type { ButtonProps } from 'antd';
+import { Button } from 'antd';
+import React from 'react';
+import { WalletIcon } from './WalletIcon.js';
+
+type Props = ButtonProps &
+    Readonly<{
+        wallet?: Wallet;
+    }>;
+
+export function WalletButtonBase({
+    htmlType = 'button',
+    size = 'large',
+    type = 'primary',
+    wallet,
+    ...buttonProps
+}: Props) {
+    return (
+        <Button
+            {...buttonProps}
+            htmlType={htmlType}
+            icon={wallet ? <WalletIcon wallet={wallet} /> : undefined}
+            size={size}
+            type={type}
+        />
+    );
+}

--- a/packages/ui/ant-design/src/WalletConnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletConnectButton.tsx
@@ -1,52 +1,47 @@
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWalletButton } from '@solana/wallet-adapter-react';
 import type { ButtonProps } from 'antd';
-import { Button } from 'antd';
-import type { FC, MouseEventHandler } from 'react';
+import type { FC, MouseEvent } from 'react';
 import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import { WalletButtonBase } from './WalletButonBase.js';
 
-export const WalletConnectButton: FC<ButtonProps> = ({
-    type = 'primary',
-    size = 'large',
-    htmlType = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, connect, connecting, connected } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
+export const WalletConnectButton: FC<ButtonProps> = ({ children, disabled, onClick, ...props }) => {
+    const walletButtonState = useWalletButton();
+    const { walletState } = walletButtonState;
+    const handleClick = useCallback(
+        (event: MouseEvent<HTMLButtonElement>) => {
             if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                connect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
+            if (!event.defaultPrevented) {
+                if ('onConnect' in walletButtonState) {
+                    walletButtonState.onConnect();
+                }
+            }
         },
-        [onClick, connect]
+        [onClick, walletButtonState]
     );
-
-    const content = useMemo(() => {
+    const label = useMemo(() => {
         if (children) return children;
-        if (connecting) return 'Connecting ...';
-        if (connected) return 'Connected';
-        if (wallet) return 'Connect';
-        return 'Connect Wallet';
-    }, [children, connecting, connected, wallet]);
-
+        switch (walletState) {
+            case 'connecting':
+                return 'Connecting ...';
+            case 'connected':
+                return 'Connected';
+            default:
+                return 'wallet' in walletButtonState ? 'Connect' : 'Connect Wallet';
+        }
+    }, [children, walletButtonState, walletState]);
     return (
-        <Button
-            onClick={handleClick}
-            disabled={disabled || !wallet || connecting || connected}
-            icon={<WalletIcon wallet={wallet} />}
-            type={type}
-            size={size}
-            htmlType={htmlType}
+        <WalletButtonBase
             {...props}
+            disabled={
+                disabled ||
+                !('wallet' in walletButtonState) ||
+                walletState === 'connected' ||
+                walletState === 'connecting'
+            }
+            onClick={handleClick}
+            wallet={'wallet' in walletButtonState ? walletButtonState.wallet : undefined}
         >
-            {content}
-        </Button>
+            {label}
+        </WalletButtonBase>
     );
 };

--- a/packages/ui/ant-design/src/WalletDisconnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletDisconnectButton.tsx
@@ -1,51 +1,42 @@
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWalletButton } from '@solana/wallet-adapter-react';
 import type { ButtonProps } from 'antd';
-import { Button } from 'antd';
-import type { FC, MouseEventHandler } from 'react';
+import type { FC, MouseEvent } from 'react';
 import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import { WalletButtonBase } from './WalletButonBase.js';
 
-export const WalletDisconnectButton: FC<ButtonProps> = ({
-    type = 'primary',
-    size = 'large',
-    htmlType = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
+export const WalletDisconnectButton: FC<ButtonProps> = ({ children, disabled, onClick, ...props }) => {
+    const walletButtonState = useWalletButton();
+    const { walletState } = walletButtonState;
+    const handleClick = useCallback(
+        (event: MouseEvent<HTMLButtonElement>) => {
             if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                disconnect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
+            if (!event.defaultPrevented) {
+                if ('onDisconnect' in walletButtonState) {
+                    walletButtonState.onDisconnect();
+                } else if (walletButtonState.walletState === 'disconnected') {
+                    walletButtonState.onSelectWallet(null);
+                }
+            }
         },
-        [onClick, disconnect]
+        [onClick, walletButtonState]
     );
-
-    const content = useMemo(() => {
+    const label = useMemo(() => {
         if (children) return children;
-        if (disconnecting) return 'Disconnecting ...';
-        if (wallet) return 'Disconnect';
-        return 'Disconnect Wallet';
-    }, [children, disconnecting, wallet]);
-
+        switch (walletState) {
+            case 'disconnecting':
+                return 'Disconnecting ...';
+            default:
+                return 'wallet' in walletButtonState ? 'Disconnect' : 'Disconnect Wallet';
+        }
+    }, [children, walletButtonState, walletState]);
     return (
-        <Button
-            onClick={handleClick}
-            disabled={disabled || !wallet}
-            icon={<WalletIcon wallet={wallet} />}
-            type={type}
-            size={size}
-            htmlType={htmlType}
+        <WalletButtonBase
             {...props}
+            disabled={disabled || !('wallet' in walletButtonState)}
+            onClick={handleClick}
+            wallet={'wallet' in walletButtonState ? walletButtonState.wallet : undefined}
         >
-            {content}
-        </Button>
+            {label}
+        </WalletButtonBase>
     );
 };

--- a/packages/ui/ant-design/src/WalletModalButton.tsx
+++ b/packages/ui/ant-design/src/WalletModalButton.tsx
@@ -1,17 +1,10 @@
 import type { ButtonProps } from 'antd';
-import { Button } from 'antd';
 import type { FC, MouseEventHandler } from 'react';
 import React, { useCallback } from 'react';
+import { WalletButtonBase } from './WalletButonBase.js';
 import { useWalletModal } from './useWalletModal.js';
 
-export const WalletModalButton: FC<ButtonProps> = ({
-    children = 'Select Wallet',
-    type = 'primary',
-    size = 'large',
-    htmlType = 'button',
-    onClick,
-    ...props
-}) => {
+export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet', onClick, ...props }) => {
     const { setVisible } = useWalletModal();
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
@@ -23,8 +16,8 @@ export const WalletModalButton: FC<ButtonProps> = ({
     );
 
     return (
-        <Button onClick={handleClick} type={type} size={size} htmlType={htmlType} {...props}>
+        <WalletButtonBase {...props} onClick={handleClick}>
             {children}
-        </Button>
+        </WalletButtonBase>
     );
 };

--- a/packages/ui/material-ui/src/WalletButtonBase.tsx
+++ b/packages/ui/material-ui/src/WalletButtonBase.tsx
@@ -1,0 +1,28 @@
+import type { ButtonProps } from '@mui/material';
+import { Button } from '@mui/material';
+import type { Wallet } from '@solana/wallet-adapter-react';
+import React from 'react';
+import { WalletIcon } from './WalletIcon.js';
+
+type Props = ButtonProps &
+    Readonly<{
+        wallet?: Wallet;
+    }>;
+
+export function WalletButtonBase({
+    color = 'primary',
+    variant = 'contained',
+    type = 'button',
+    wallet,
+    ...buttonProps
+}: Props) {
+    return (
+        <Button
+            {...buttonProps}
+            color={color}
+            variant={variant}
+            type={type}
+            startIcon={wallet ? <WalletIcon wallet={wallet} /> : undefined}
+        />
+    );
+}

--- a/packages/ui/material-ui/src/WalletConnectButton.tsx
+++ b/packages/ui/material-ui/src/WalletConnectButton.tsx
@@ -1,52 +1,47 @@
 import type { ButtonProps } from '@mui/material';
-import { Button } from '@mui/material';
-import { useWallet } from '@solana/wallet-adapter-react';
-import type { FC, MouseEventHandler } from 'react';
+import { useWalletButton } from '@solana/wallet-adapter-react';
+import type { FC, MouseEvent } from 'react';
 import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import { WalletButtonBase } from './WalletButtonBase.js';
 
-export const WalletConnectButton: FC<ButtonProps> = ({
-    color = 'primary',
-    variant = 'contained',
-    type = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, connect, connecting, connected } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
+export const WalletConnectButton: FC<ButtonProps> = ({ children, disabled, onClick, ...props }) => {
+    const walletButtonState = useWalletButton();
+    const { walletState } = walletButtonState;
+    const handleClick = useCallback(
+        (event: MouseEvent<HTMLButtonElement>) => {
             if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                connect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
+            if (!event.defaultPrevented) {
+                if ('onConnect' in walletButtonState) {
+                    walletButtonState.onConnect();
+                }
+            }
         },
-        [onClick, connect]
+        [onClick, walletButtonState]
     );
-
-    const content = useMemo(() => {
+    const label = useMemo(() => {
         if (children) return children;
-        if (connecting) return 'Connecting ...';
-        if (connected) return 'Connected';
-        if (wallet) return 'Connect';
-        return 'Connect Wallet';
-    }, [children, connecting, connected, wallet]);
-
+        switch (walletState) {
+            case 'connecting':
+                return 'Connecting ...';
+            case 'connected':
+                return 'Connected';
+            default:
+                return 'wallet' in walletButtonState ? 'Connect' : 'Connect Wallet';
+        }
+    }, [children, walletButtonState, walletState]);
     return (
-        <Button
-            color={color}
-            variant={variant}
-            type={type}
-            onClick={handleClick}
-            disabled={disabled || !wallet || connecting || connected}
-            startIcon={<WalletIcon wallet={wallet} />}
+        <WalletButtonBase
             {...props}
+            disabled={
+                disabled ||
+                !('wallet' in walletButtonState) ||
+                walletState === 'connected' ||
+                walletState === 'connecting'
+            }
+            onClick={handleClick}
+            wallet={'wallet' in walletButtonState ? walletButtonState.wallet : undefined}
         >
-            {content}
-        </Button>
+            {label}
+        </WalletButtonBase>
     );
 };

--- a/packages/ui/react-ui/src/WalletButtonBase.tsx
+++ b/packages/ui/react-ui/src/WalletButtonBase.tsx
@@ -1,0 +1,20 @@
+import type { Wallet } from '@solana/wallet-adapter-react';
+import React from 'react';
+import type { ButtonProps } from './Button.js';
+import { Button } from './Button.js';
+import { WalletIcon } from './WalletIcon.js';
+
+type Props = ButtonProps &
+    Readonly<{
+        wallet?: Wallet;
+    }>;
+
+export function WalletButtonBase({ wallet, ...buttonProps }: Props) {
+    return (
+        <Button
+            {...buttonProps}
+            className="wallet-adapter-button-trigger"
+            startIcon={wallet ? <WalletIcon wallet={wallet} /> : undefined}
+        />
+    );
+}

--- a/packages/ui/react-ui/src/WalletModalButton.tsx
+++ b/packages/ui/react-ui/src/WalletModalButton.tsx
@@ -1,7 +1,7 @@
 import type { FC, MouseEvent } from 'react';
 import React, { useCallback } from 'react';
 import type { ButtonProps } from './Button.js';
-import { Button } from './Button.js';
+import { WalletButtonBase } from './WalletButtonBase.js';
 import { useWalletModal } from './useWalletModal.js';
 
 export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet', onClick, ...props }) => {
@@ -16,8 +16,8 @@ export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet',
     );
 
     return (
-        <Button className="wallet-adapter-button-trigger" onClick={handleClick} {...props}>
+        <WalletButtonBase {...props} onClick={handleClick}>
             {children}
-        </Button>
+        </WalletButtonBase>
     );
 };

--- a/packages/ui/react-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/react-ui/src/WalletMultiButton.tsx
@@ -1,47 +1,34 @@
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWalletButton } from '@solana/wallet-adapter-react';
 import type { FC } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ButtonProps } from './Button.js';
-import { Button } from './Button.js';
-import { useWalletModal } from './useWalletModal.js';
+import { WalletButtonBase } from './WalletButtonBase.js';
 import { WalletConnectButton } from './WalletConnectButton.js';
-import { WalletIcon } from './WalletIcon.js';
 import { WalletModalButton } from './WalletModalButton.js';
+import { useWalletModal } from './useWalletModal.js';
 
 export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
-    const { publicKey, wallet, disconnect } = useWallet();
     const { setVisible } = useWalletModal();
     const [copied, setCopied] = useState(false);
-    const [active, setActive] = useState(false);
+    const [dropdownOpen, setDropdownOpen] = useState(false);
     const ref = useRef<HTMLUListElement>(null);
 
-    const base58 = useMemo(() => publicKey?.toBase58(), [publicKey]);
+    const onSelectWallet = useCallback(() => {
+        setDropdownOpen(false);
+        setVisible(true);
+    }, [setVisible]);
+
+    const walletButtonState = useWalletButton();
+
+    const base58 = useMemo(
+        () => ('publicKey' in walletButtonState ? walletButtonState.publicKey.toBase58() : null),
+        [walletButtonState]
+    );
     const content = useMemo(() => {
         if (children) return children;
-        if (!wallet || !base58) return null;
+        if (!base58) return null;
         return base58.slice(0, 4) + '..' + base58.slice(-4);
-    }, [children, wallet, base58]);
-
-    const copyAddress = useCallback(async () => {
-        if (base58) {
-            await navigator.clipboard.writeText(base58);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 400);
-        }
-    }, [base58]);
-
-    const openDropdown = useCallback(() => {
-        setActive(true);
-    }, []);
-
-    const closeDropdown = useCallback(() => {
-        setActive(false);
-    }, []);
-
-    const openModal = useCallback(() => {
-        setVisible(true);
-        closeDropdown();
-    }, [setVisible, closeDropdown]);
+    }, [base58, children]);
 
     useEffect(() => {
         const listener = (event: MouseEvent | TouchEvent) => {
@@ -50,7 +37,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
             // Do nothing if clicking dropdown or its descendants
             if (!node || node.contains(event.target as Node)) return;
 
-            closeDropdown();
+            setDropdownOpen(false);
         };
 
         document.addEventListener('mousedown', listener);
@@ -60,38 +47,53 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
             document.removeEventListener('mousedown', listener);
             document.removeEventListener('touchstart', listener);
         };
-    }, [ref, closeDropdown]);
+    }, [ref]);
 
-    if (!wallet) return <WalletModalButton {...props}>{children}</WalletModalButton>;
+    if (walletButtonState.walletState === 'no-wallet') {
+        return <WalletModalButton {...props}>{children}</WalletModalButton>;
+    }
     if (!base58) return <WalletConnectButton {...props}>{children}</WalletConnectButton>;
 
     return (
         <div className="wallet-adapter-dropdown">
-            <Button
-                aria-expanded={active}
-                className="wallet-adapter-button-trigger"
-                style={{ pointerEvents: active ? 'none' : 'auto', ...props.style }}
-                onClick={openDropdown}
-                startIcon={<WalletIcon wallet={wallet} />}
+            <WalletButtonBase
                 {...props}
+                aria-expanded={dropdownOpen}
+                style={{ pointerEvents: dropdownOpen ? 'none' : 'auto', ...props.style }}
+                onClick={() => setDropdownOpen(true)}
+                wallet={'wallet' in walletButtonState ? walletButtonState.wallet : undefined}
             >
                 {content}
-            </Button>
+            </WalletButtonBase>
             <ul
                 aria-label="dropdown-list"
-                className={`wallet-adapter-dropdown-list ${active && 'wallet-adapter-dropdown-list-active'}`}
+                className={`wallet-adapter-dropdown-list ${dropdownOpen && 'wallet-adapter-dropdown-list-active'}`}
                 ref={ref}
                 role="menu"
             >
-                <li onClick={copyAddress} className="wallet-adapter-dropdown-list-item" role="menuitem">
+                <li
+                    onClick={async () => {
+                        await navigator.clipboard.writeText(base58);
+                        setCopied(true);
+                        setTimeout(() => setCopied(false), 400);
+                    }}
+                    className="wallet-adapter-dropdown-list-item"
+                    role="menuitem"
+                >
                     {copied ? 'Copied' : 'Copy address'}
                 </li>
-                <li onClick={openModal} className="wallet-adapter-dropdown-list-item" role="menuitem">
+                <li onClick={onSelectWallet} className="wallet-adapter-dropdown-list-item" role="menuitem">
                     Change wallet
                 </li>
-                <li onClick={disconnect} className="wallet-adapter-dropdown-list-item" role="menuitem">
-                    Disconnect
-                </li>
+                {'onDisconnect' in walletButtonState ? (
+                    <li
+                        onClick={walletButtonState.onDisconnect}
+                        className="wallet-adapter-dropdown-list-item"
+                        role="menuitem"
+                    >
+                        Disconnect
+                    </li>
+                ) : null}
             </ul>
         </div>
     );


### PR DESCRIPTION
feat: implement the starter UI atop the new `useWalletState` hook
## Summary

This PR proves out the `useWalletState` hook by re-implementing the UI packages atop it. The UI packages no longer use `useWallet`, and have less connection-wrangling logic. This establishes a pattern that other developers can use to ship their own custom wallet connection UI.

## Test Plan

Loaded the example app and all three starter apps. Buttons work as they did before.

Finishes #658.
