### PR TITLE
feat: implement the React UI starter UI atop the new wallet UI hooks

### DIFF
--- a/packages/core/react/README.md
+++ b/packages/core/react/README.md
@@ -1,5 +1,97 @@
 # `@solana/wallet-adapter-react`
 
-<!-- @TODO -->
+## Creating a custom connect button
 
-Coming soon.
+This package exports a series of hooks that you can use to create custom wallet connection buttons. They manage the state of the wallet connection for you, and return helper methods that you can attach to your event handlers.
+
+What follows is the documentation for `useWalletMultiButton()`.
+
+### States
+
+-   `no-wallet` \
+    In this state you are neither connected nor is there a wallet selected. Allow your users to select from the list of `wallets`, then call `onSelectWallet()` with the name of the wallet they chose.
+-   `has-wallet` \
+    This state implies that there is a wallet selected, but that your app is not connected to it. Render a connect button that calls `onConnect()` when clicked.
+-   `disconnecting` \
+    When in this state, the last-connected wallet is in mid-disconnection.
+-   `connected` \
+    In this state, you have access to the connected `publicKey` and an `onDisconnect()` method that you can call to disconnect from the wallet. At any time you can call `onSelectWallet()` to change wallets.
+-   `connecting` \
+    When in this state, the wallet is in mid-connection.
+
+### Functions
+
+-   `onConnect` \
+     Connects the currently selected wallet. Available in the `has-wallet` state.
+-   `onDisconnect` \
+     Disconnects the currently selected wallet. Available in the `has-wallet`, `connected`, and `connecting` states.
+-   `onSelectWallet()` \
+     Calls the `onSelectWallet()` function that you supplied as config to `useWalletMultiButton`. That function receives the list of `wallets` and offers you an `onSelectWallet()` callback that you can call with the name of the wallet to switch to.
+
+### Example
+
+```ts
+function CustomConnectButton() {
+    const [walletModalConfig, setWalletModalConfig] = useState<Readonly<{
+        onSelectWallet(walletName: WalletName): void;
+        wallets: Wallet[];
+    }> | null>(null);
+    const { buttonState, onConnect, onDisconnect, onSelectWallet } = useWalletMultiButton({
+        onSelectWallet: setWalletModalConfig,
+    });
+    let label;
+    switch (buttonState) {
+        case 'connected':
+            label = 'Disconnect';
+            break;
+        case 'connecting':
+            label = 'Connecting';
+            break;
+        case 'disconnecting':
+            label = 'Disconnecting';
+            break;
+        case 'has-wallet':
+            label = 'Connect';
+            break;
+        case 'no-wallet':
+            label = 'Select Wallet';
+            break;
+    }
+    const handleClick = useCallback(() => {
+        switch (buttonState) {
+            case 'connected':
+                return onDisconnect;
+            case 'connecting':
+            case 'disconnecting':
+                break;
+            case 'has-wallet':
+                return onConnect;
+            case 'no-wallet':
+                return onSelectWallet;
+                break;
+        }
+    }, [buttonState, onDisconnect, onConnect, onSelectWallet]);
+    return (
+        <>
+            <button disabled={buttonState === 'connecting' || buttonState === 'disconnecting'} onClick={handleClick}>
+                {label}
+            </button>
+            {walletModalConfig ? (
+                <Modal>
+                    {walletModalConfig.wallets.map((wallet) => (
+                        <button
+                            key={wallet.adapter.name}
+                            onClick={() => {
+                                walletModalConfig.onSelectWallet(wallet.adapter.name);
+                                setWalletModalConfig(null);
+                            }}
+                        >
+                            {wallet.adapter.name}
+                        </button>
+                    ))}
+                </Modal>
+            ) : null}
+        </>
+    );
+}
+```

--- a/packages/core/react/src/index.ts
+++ b/packages/core/react/src/index.ts
@@ -4,4 +4,7 @@ export * from './useAnchorWallet.js';
 export * from './useConnection.js';
 export * from './useLocalStorage.js';
 export * from './useWallet.js';
+export * from './useWalletConnectButton.js';
+export * from './useWalletDisconnectButton.js';
+export * from './useWalletMultiButton.js';
 export * from './WalletProvider.js';

--- a/packages/core/react/src/useWalletConnectButton.ts
+++ b/packages/core/react/src/useWalletConnectButton.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import type { Wallet } from './useWallet.js';
+import { useWallet } from './useWallet.js';
+
+type ButtonState = {
+    buttonDisabled: boolean;
+    buttonState: 'connecting' | 'connected' | 'has-wallet' | 'no-wallet';
+    onButtonClick?: () => void;
+    walletIcon?: Wallet['adapter']['icon'];
+    walletName?: Wallet['adapter']['name'];
+};
+
+export function useWalletConnectButton(): ButtonState {
+    const { connect, connected, connecting, wallet } = useWallet();
+    let buttonState: ButtonState['buttonState'];
+    if (connecting) {
+        buttonState = 'connecting';
+    } else if (connected) {
+        buttonState = 'connected';
+    } else if (wallet) {
+        buttonState = 'has-wallet';
+    } else {
+        buttonState = 'no-wallet';
+    }
+    const handleConnectButtonClick = useCallback(() => {
+        connect().catch(() => {
+            // Silently catch because any errors are caught by the context `onError` handler
+        });
+    }, [connect]);
+    return {
+        buttonDisabled: buttonState !== 'has-wallet',
+        buttonState,
+        onButtonClick: buttonState === 'has-wallet' ? handleConnectButtonClick : undefined,
+        walletIcon: wallet?.adapter.icon,
+        walletName: wallet?.adapter.name,
+    };
+}

--- a/packages/core/react/src/useWalletDisconnectButton.ts
+++ b/packages/core/react/src/useWalletDisconnectButton.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+import type { Wallet } from './useWallet.js';
+import { useWallet } from './useWallet.js';
+
+type ButtonState = {
+    buttonDisabled: boolean;
+    buttonState: 'disconnecting' | 'has-wallet' | 'no-wallet';
+    onButtonClick?: () => void;
+    walletIcon?: Wallet['adapter']['icon'];
+    walletName?: Wallet['adapter']['name'];
+};
+
+export function useWalletDisconnectButton(): ButtonState {
+    const { disconnecting, disconnect, wallet } = useWallet();
+    let buttonState: ButtonState['buttonState'];
+    if (disconnecting) {
+        buttonState = 'disconnecting';
+    } else if (wallet) {
+        buttonState = 'has-wallet';
+    } else {
+        buttonState = 'no-wallet';
+    }
+    const handleDisconnectButtonClick = useCallback(() => {
+        disconnect().catch(() => {
+            // Silently catch because any errors are caught by the context `onError` handler
+        });
+    }, [disconnect]);
+    return {
+        buttonDisabled: buttonState !== 'has-wallet',
+        buttonState,
+        onButtonClick: buttonState === 'has-wallet' ? handleDisconnectButtonClick : undefined,
+        walletIcon: wallet?.adapter.icon,
+        walletName: wallet?.adapter.name,
+    };
+}

--- a/packages/core/react/src/useWalletMultiButton.ts
+++ b/packages/core/react/src/useWalletMultiButton.ts
@@ -1,0 +1,60 @@
+import type { PublicKey } from '@solana/web3.js';
+import { useCallback } from 'react';
+import type { Wallet } from './useWallet.js';
+import { useWallet } from './useWallet.js';
+
+type ButtonState = {
+    buttonState: 'connecting' | 'connected' | 'disconnecting' | 'has-wallet' | 'no-wallet';
+    onConnect?: () => void;
+    onDisconnect?: () => void;
+    onSelectWallet?: () => void;
+    publicKey?: PublicKey;
+    walletIcon?: Wallet['adapter']['icon'];
+    walletName?: Wallet['adapter']['name'];
+};
+
+type Config = {
+    onSelectWallet: (config: {
+        onSelectWallet: (walletName: Wallet['adapter']['name']) => void;
+        wallets: Wallet[];
+    }) => void;
+};
+
+export function useWalletMultiButton({ onSelectWallet }: Config): ButtonState {
+    const { connect, connected, connecting, disconnect, disconnecting, publicKey, select, wallet, wallets } =
+        useWallet();
+    let buttonState: ButtonState['buttonState'];
+    if (connecting) {
+        buttonState = 'connecting';
+    } else if (connected) {
+        buttonState = 'connected';
+    } else if (disconnecting) {
+        buttonState = 'disconnecting';
+    } else if (wallet) {
+        buttonState = 'has-wallet';
+    } else {
+        buttonState = 'no-wallet';
+    }
+    const handleConnect = useCallback(() => {
+        connect().catch(() => {
+            // Silently catch because any errors are caught by the context `onError` handler
+        });
+    }, [connect]);
+    const handleDisconnect = useCallback(() => {
+        disconnect().catch(() => {
+            // Silently catch because any errors are caught by the context `onError` handler
+        });
+    }, [disconnect]);
+    const handleSelectWallet = useCallback(() => {
+        onSelectWallet({ onSelectWallet: select, wallets });
+    }, [onSelectWallet, select, wallets]);
+    return {
+        buttonState,
+        onConnect: buttonState === 'has-wallet' ? handleConnect : undefined,
+        onDisconnect: buttonState !== 'disconnecting' && buttonState !== 'no-wallet' ? handleDisconnect : undefined,
+        onSelectWallet: handleSelectWallet,
+        publicKey: publicKey ?? undefined,
+        walletIcon: wallet?.adapter.icon,
+        walletName: wallet?.adapter.name,
+    };
+}

--- a/packages/ui/ant-design/src/BaseWalletConnectionButton.tsx
+++ b/packages/ui/ant-design/src/BaseWalletConnectionButton.tsx
@@ -1,0 +1,34 @@
+import type { ButtonProps } from 'antd';
+import { Button } from 'antd';
+import React from 'react';
+
+import type { WalletName } from '@solana/wallet-adapter-base';
+import { WalletIcon } from './WalletIcon.js';
+
+type Props = ButtonProps & {
+    walletIcon?: string;
+    walletName?: WalletName;
+};
+
+export function BaseWalletConnectionButton({
+    htmlType = 'button',
+    size = 'large',
+    type = 'primary',
+    walletIcon,
+    walletName,
+    ...props
+}: Props) {
+    return (
+        <Button
+            {...props}
+            htmlType={htmlType}
+            icon={
+                walletIcon && walletName ? (
+                    <WalletIcon wallet={{ adapter: { icon: walletIcon, name: walletName } }} />
+                ) : undefined
+            }
+            type={type}
+            size={size}
+        />
+    );
+}

--- a/packages/ui/ant-design/src/WalletConnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletConnectButton.tsx
@@ -1,52 +1,41 @@
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWalletConnectButton } from '@solana/wallet-adapter-react';
 import type { ButtonProps } from 'antd';
-import { Button } from 'antd';
-import type { FC, MouseEventHandler } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import React from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 
-export const WalletConnectButton: FC<ButtonProps> = ({
-    type = 'primary',
-    size = 'large',
-    htmlType = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, connect, connecting, connected } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
-            if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                connect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
-        },
-        [onClick, connect]
-    );
-
-    const content = useMemo(() => {
-        if (children) return children;
-        if (connecting) return 'Connecting ...';
-        if (connected) return 'Connected';
-        if (wallet) return 'Connect';
-        return 'Connect Wallet';
-    }, [children, connecting, connected, wallet]);
-
+export function WalletConnectButton({ children, disabled, onClick, ...props }: ButtonProps) {
+    const { buttonDisabled, buttonState, onButtonClick, walletIcon, walletName } = useWalletConnectButton();
+    let label;
+    if (children) {
+        label = children;
+    } else if (buttonState === 'connecting') {
+        label = 'Connecting ...';
+    } else if (buttonState === 'connected') {
+        label = 'Connected';
+    } else if (buttonState === 'has-wallet') {
+        label = 'Connect';
+    } else {
+        label = 'Connect Wallet';
+    }
     return (
-        <Button
-            onClick={handleClick}
-            disabled={disabled || !wallet || connecting || connected}
-            icon={<WalletIcon wallet={wallet} />}
-            type={type}
-            size={size}
-            htmlType={htmlType}
+        <BaseWalletConnectionButton
             {...props}
+            disabled={disabled || buttonDisabled}
+            onClick={(e) => {
+                if (onClick) {
+                    onClick(e);
+                }
+                if (e.defaultPrevented) {
+                    return;
+                }
+                if (onButtonClick) {
+                    onButtonClick();
+                }
+            }}
+            walletIcon={walletIcon}
+            walletName={walletName}
         >
-            {content}
-        </Button>
+            {label}
+        </BaseWalletConnectionButton>
     );
-};
+}

--- a/packages/ui/ant-design/src/WalletDisconnectButton.tsx
+++ b/packages/ui/ant-design/src/WalletDisconnectButton.tsx
@@ -1,51 +1,39 @@
-import { useWallet } from '@solana/wallet-adapter-react';
+import { useWalletDisconnectButton } from '@solana/wallet-adapter-react';
 import type { ButtonProps } from 'antd';
-import { Button } from 'antd';
-import type { FC, MouseEventHandler } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import React from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 
-export const WalletDisconnectButton: FC<ButtonProps> = ({
-    type = 'primary',
-    size = 'large',
-    htmlType = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
-            if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                disconnect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
-        },
-        [onClick, disconnect]
-    );
-
-    const content = useMemo(() => {
-        if (children) return children;
-        if (disconnecting) return 'Disconnecting ...';
-        if (wallet) return 'Disconnect';
-        return 'Disconnect Wallet';
-    }, [children, disconnecting, wallet]);
-
+export function WalletDisconnectButton({ children, disabled, onClick, ...props }: ButtonProps) {
+    const { buttonDisabled, buttonState, onButtonClick, walletIcon, walletName } = useWalletDisconnectButton();
+    let label;
+    if (children) {
+        label = children;
+    } else if (buttonState === 'disconnecting') {
+        label = 'Disconnecting ...';
+    } else if (buttonState === 'has-wallet') {
+        label = 'Disconnect';
+    } else {
+        label = 'Disconnect Wallet';
+    }
     return (
-        <Button
-            onClick={handleClick}
-            disabled={disabled || !wallet}
-            icon={<WalletIcon wallet={wallet} />}
-            type={type}
-            size={size}
-            htmlType={htmlType}
+        <BaseWalletConnectionButton
             {...props}
+            disabled={disabled || buttonDisabled}
+            onClick={(e) => {
+                if (onClick) {
+                    onClick(e);
+                }
+                if (e.defaultPrevented) {
+                    return;
+                }
+                if (onButtonClick) {
+                    onButtonClick();
+                }
+            }}
+            walletIcon={walletIcon}
+            walletName={walletName}
         >
-            {content}
-        </Button>
+            {label}
+        </BaseWalletConnectionButton>
     );
-};
+}

--- a/packages/ui/ant-design/src/WalletIcon.tsx
+++ b/packages/ui/ant-design/src/WalletIcon.tsx
@@ -3,7 +3,7 @@ import type { DetailedHTMLProps, FC, ImgHTMLAttributes } from 'react';
 import React from 'react';
 
 export interface WalletIconProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
-    wallet: Wallet | null;
+    wallet: { adapter: Pick<Wallet['adapter'], 'icon' | 'name'> } | null;
 }
 
 export const WalletIcon: FC<WalletIconProps> = ({ wallet, ...props }) => {

--- a/packages/ui/ant-design/src/WalletModalButton.tsx
+++ b/packages/ui/ant-design/src/WalletModalButton.tsx
@@ -1,17 +1,10 @@
 import type { ButtonProps } from 'antd';
-import { Button } from 'antd';
 import type { FC, MouseEventHandler } from 'react';
 import React, { useCallback } from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 import { useWalletModal } from './useWalletModal.js';
 
-export const WalletModalButton: FC<ButtonProps> = ({
-    children = 'Select Wallet',
-    type = 'primary',
-    size = 'large',
-    htmlType = 'button',
-    onClick,
-    ...props
-}) => {
+export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet', onClick, ...props }) => {
     const { setVisible } = useWalletModal();
 
     const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
@@ -23,8 +16,8 @@ export const WalletModalButton: FC<ButtonProps> = ({
     );
 
     return (
-        <Button onClick={handleClick} type={type} size={size} htmlType={htmlType} {...props}>
+        <BaseWalletConnectionButton {...props} onClick={handleClick}>
             {children}
-        </Button>
+        </BaseWalletConnectionButton>
     );
 };

--- a/packages/ui/material-ui/src/BaseWalletConnectionButton.tsx
+++ b/packages/ui/material-ui/src/BaseWalletConnectionButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import type { ButtonProps } from '@mui/material';
+import { Button } from '@mui/material';
+import type { WalletName } from '@solana/wallet-adapter-base';
+import { WalletIcon } from './WalletIcon.js';
+
+type Props = ButtonProps & {
+    walletIcon?: string;
+    walletName?: WalletName;
+};
+
+export const BaseWalletConnectionButton = React.forwardRef(function BaseWalletConnectionButton(
+    { color = 'primary', type = 'button', walletIcon, walletName, variant = 'contained', ...props }: Props,
+    forwardedRef: React.Ref<HTMLButtonElement>
+) {
+    return (
+        <Button
+            {...props}
+            color={color}
+            startIcon={
+                walletIcon && walletName ? (
+                    <WalletIcon wallet={{ adapter: { icon: walletIcon, name: walletName } }} />
+                ) : undefined
+            }
+            ref={forwardedRef}
+            type={type}
+            variant={variant}
+        />
+    );
+});

--- a/packages/ui/material-ui/src/WalletConnectButton.tsx
+++ b/packages/ui/material-ui/src/WalletConnectButton.tsx
@@ -1,52 +1,42 @@
 import type { ButtonProps } from '@mui/material';
-import { Button } from '@mui/material';
-import { useWallet } from '@solana/wallet-adapter-react';
-import type { FC, MouseEventHandler } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import React from 'react';
 
-export const WalletConnectButton: FC<ButtonProps> = ({
-    color = 'primary',
-    variant = 'contained',
-    type = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, connect, connecting, connected } = useWallet();
+import { useWalletConnectButton } from '@solana/wallet-adapter-react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
-            if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                connect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
-        },
-        [onClick, connect]
-    );
-
-    const content = useMemo(() => {
-        if (children) return children;
-        if (connecting) return 'Connecting ...';
-        if (connected) return 'Connected';
-        if (wallet) return 'Connect';
-        return 'Connect Wallet';
-    }, [children, connecting, connected, wallet]);
-
+export function WalletConnectButton({ children, disabled, onClick, ...props }: ButtonProps) {
+    const { buttonDisabled, buttonState, onButtonClick, walletIcon, walletName } = useWalletConnectButton();
+    let label;
+    if (children) {
+        label = children;
+    } else if (buttonState === 'connecting') {
+        label = 'Connecting ...';
+    } else if (buttonState === 'connected') {
+        label = 'Connected';
+    } else if (buttonState === 'has-wallet') {
+        label = 'Connect';
+    } else {
+        label = 'Connect Wallet';
+    }
     return (
-        <Button
-            color={color}
-            variant={variant}
-            type={type}
-            onClick={handleClick}
-            disabled={disabled || !wallet || connecting || connected}
-            startIcon={<WalletIcon wallet={wallet} />}
+        <BaseWalletConnectionButton
             {...props}
+            disabled={disabled || buttonDisabled}
+            onClick={(e) => {
+                if (onClick) {
+                    onClick(e);
+                }
+                if (e.defaultPrevented) {
+                    return;
+                }
+                if (onButtonClick) {
+                    onButtonClick();
+                }
+            }}
+            walletIcon={walletIcon}
+            walletName={walletName}
         >
-            {content}
-        </Button>
+            {label}
+        </BaseWalletConnectionButton>
     );
-};
+}

--- a/packages/ui/material-ui/src/WalletDisconnectButton.tsx
+++ b/packages/ui/material-ui/src/WalletDisconnectButton.tsx
@@ -1,51 +1,39 @@
+import { useWalletDisconnectButton } from '@solana/wallet-adapter-react';
 import type { ButtonProps } from '@mui/material';
-import { Button } from '@mui/material';
-import { useWallet } from '@solana/wallet-adapter-react';
-import type { FC, MouseEventHandler } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import { WalletIcon } from './WalletIcon.js';
+import React from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 
-export const WalletDisconnectButton: FC<ButtonProps> = ({
-    color = 'primary',
-    variant = 'contained',
-    type = 'button',
-    children,
-    disabled,
-    onClick,
-    ...props
-}) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
-            if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented)
-                disconnect().catch(() => {
-                    // Silently catch because any errors are caught by the context `onError` handler
-                });
-        },
-        [onClick, disconnect]
-    );
-
-    const content = useMemo(() => {
-        if (children) return children;
-        if (disconnecting) return 'Disconnecting ...';
-        if (wallet) return 'Disconnect';
-        return 'Disconnect Wallet';
-    }, [children, disconnecting, wallet]);
-
+export function WalletDisconnectButton({ children, disabled, onClick, ...props }: ButtonProps) {
+    const { buttonDisabled, buttonState, onButtonClick, walletIcon, walletName } = useWalletDisconnectButton();
+    let label;
+    if (children) {
+        label = children;
+    } else if (buttonState === 'disconnecting') {
+        label = 'Disconnecting ...';
+    } else if (buttonState === 'has-wallet') {
+        label = 'Disconnect';
+    } else {
+        label = 'Disconnect Wallet';
+    }
     return (
-        <Button
-            color={color}
-            variant={variant}
-            type={type}
-            onClick={handleClick}
-            disabled={disabled || !wallet}
-            startIcon={<WalletIcon wallet={wallet} />}
+        <BaseWalletConnectionButton
             {...props}
+            disabled={disabled || buttonDisabled}
+            onClick={(e) => {
+                if (onClick) {
+                    onClick(e);
+                }
+                if (e.defaultPrevented) {
+                    return;
+                }
+                if (onButtonClick) {
+                    onButtonClick();
+                }
+            }}
+            walletIcon={walletIcon}
+            walletName={walletName}
         >
-            {content}
-        </Button>
+            {label}
+        </BaseWalletConnectionButton>
     );
-};
+}

--- a/packages/ui/material-ui/src/WalletIcon.tsx
+++ b/packages/ui/material-ui/src/WalletIcon.tsx
@@ -10,7 +10,7 @@ const Img = styled('img')(({ theme }: { theme: Theme }) => ({
 }));
 
 export interface WalletIconProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
-    wallet: Wallet | null;
+    wallet: { adapter: Pick<Wallet['adapter'], 'icon' | 'name'> } | null;
 }
 
 export const WalletIcon: FC<WalletIconProps> = ({ wallet, ...props }) => {

--- a/packages/ui/react-ui/src/BaseWalletConnectionButton.tsx
+++ b/packages/ui/react-ui/src/BaseWalletConnectionButton.tsx
@@ -1,0 +1,23 @@
+import type { WalletName } from '@solana/wallet-adapter-base';
+import React from 'react';
+import { Button } from './Button.js';
+import { WalletIcon } from './WalletIcon.js';
+
+type Props = React.ComponentProps<typeof Button> & {
+    walletIcon?: string;
+    walletName?: WalletName;
+};
+
+export function BaseWalletConnectionButton({ walletIcon, walletName, ...props }: Props) {
+    return (
+        <Button
+            {...props}
+            className="wallet-adapter-button-trigger"
+            startIcon={
+                walletIcon && walletName ? (
+                    <WalletIcon wallet={{ adapter: { icon: walletIcon, name: walletName } }} />
+                ) : undefined
+            }
+        />
+    );
+}

--- a/packages/ui/react-ui/src/WalletConnectButton.tsx
+++ b/packages/ui/react-ui/src/WalletConnectButton.tsx
@@ -1,39 +1,41 @@
-import { useWallet } from '@solana/wallet-adapter-react';
-import type { FC, MouseEventHandler } from 'react';
-import React, { useCallback, useMemo } from 'react';
+import { useWalletConnectButton } from '@solana/wallet-adapter-react';
+import React from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 import type { ButtonProps } from './Button.js';
-import { Button } from './Button.js';
-import { WalletIcon } from './WalletIcon.js';
 
-export const WalletConnectButton: FC<ButtonProps> = ({ children, disabled, onClick, ...props }) => {
-    const { wallet, connect, connecting, connected } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
-            if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented) connect().catch(() => {});
-        },
-        [onClick, connect]
-    );
-
-    const content = useMemo(() => {
-        if (children) return children;
-        if (connecting) return 'Connecting ...';
-        if (connected) return 'Connected';
-        if (wallet) return 'Connect';
-        return 'Connect Wallet';
-    }, [children, connecting, connected, wallet]);
-
+export function WalletConnectButton({ children, disabled, onClick, ...props }: ButtonProps) {
+    const { buttonDisabled, buttonState, onButtonClick, walletIcon, walletName } = useWalletConnectButton();
+    let label;
+    if (children) {
+        label = children;
+    } else if (buttonState === 'connecting') {
+        label = 'Connecting ...';
+    } else if (buttonState === 'connected') {
+        label = 'Connected';
+    } else if (buttonState === 'has-wallet') {
+        label = 'Connect';
+    } else {
+        label = 'Connect Wallet';
+    }
     return (
-        <Button
-            className="wallet-adapter-button-trigger"
-            disabled={disabled || !wallet || connecting || connected}
-            startIcon={wallet ? <WalletIcon wallet={wallet} /> : undefined}
-            onClick={handleClick}
+        <BaseWalletConnectionButton
             {...props}
+            disabled={disabled || buttonDisabled}
+            onClick={(e) => {
+                if (onClick) {
+                    onClick(e);
+                }
+                if (e.defaultPrevented) {
+                    return;
+                }
+                if (onButtonClick) {
+                    onButtonClick();
+                }
+            }}
+            walletIcon={walletIcon}
+            walletName={walletName}
         >
-            {content}
-        </Button>
+            {label}
+        </BaseWalletConnectionButton>
     );
-};
+}

--- a/packages/ui/react-ui/src/WalletDisconnectButton.tsx
+++ b/packages/ui/react-ui/src/WalletDisconnectButton.tsx
@@ -1,38 +1,39 @@
-import { useWallet } from '@solana/wallet-adapter-react';
-import type { FC, MouseEventHandler } from 'react';
-import React, { useCallback, useMemo } from 'react';
+import { useWalletDisconnectButton } from '@solana/wallet-adapter-react';
+import React from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 import type { ButtonProps } from './Button.js';
-import { Button } from './Button.js';
-import { WalletIcon } from './WalletIcon.js';
 
-export const WalletDisconnectButton: FC<ButtonProps> = ({ children, disabled, onClick, ...props }) => {
-    const { wallet, disconnect, disconnecting } = useWallet();
-
-    const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
-        (event) => {
-            if (onClick) onClick(event);
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            if (!event.defaultPrevented) disconnect().catch(() => {});
-        },
-        [onClick, disconnect]
-    );
-
-    const content = useMemo(() => {
-        if (children) return children;
-        if (disconnecting) return 'Disconnecting ...';
-        if (wallet) return 'Disconnect';
-        return 'Disconnect Wallet';
-    }, [children, disconnecting, wallet]);
-
+export function WalletDisconnectButton({ children, disabled, onClick, ...props }: ButtonProps) {
+    const { buttonDisabled, buttonState, onButtonClick, walletIcon, walletName } = useWalletDisconnectButton();
+    let label;
+    if (children) {
+        label = children;
+    } else if (buttonState === 'disconnecting') {
+        label = 'Disconnecting ...';
+    } else if (buttonState === 'has-wallet') {
+        label = 'Disconnect';
+    } else {
+        label = 'Disconnect Wallet';
+    }
     return (
-        <Button
-            className="wallet-adapter-button-trigger"
-            disabled={disabled || !wallet}
-            startIcon={wallet ? <WalletIcon wallet={wallet} /> : undefined}
-            onClick={handleClick}
+        <BaseWalletConnectionButton
             {...props}
+            disabled={disabled || buttonDisabled}
+            onClick={(e) => {
+                if (onClick) {
+                    onClick(e);
+                }
+                if (e.defaultPrevented) {
+                    return;
+                }
+                if (onButtonClick) {
+                    onButtonClick();
+                }
+            }}
+            walletIcon={walletIcon}
+            walletName={walletName}
         >
-            {content}
-        </Button>
+            {label}
+        </BaseWalletConnectionButton>
     );
-};
+}

--- a/packages/ui/react-ui/src/WalletIcon.tsx
+++ b/packages/ui/react-ui/src/WalletIcon.tsx
@@ -3,7 +3,7 @@ import type { DetailedHTMLProps, FC, ImgHTMLAttributes } from 'react';
 import React from 'react';
 
 export interface WalletIconProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
-    wallet: Wallet | null;
+    wallet: { adapter: Pick<Wallet['adapter'], 'icon' | 'name'> } | null;
 }
 
 export const WalletIcon: FC<WalletIconProps> = ({ wallet, ...props }) => {

--- a/packages/ui/react-ui/src/WalletModalButton.tsx
+++ b/packages/ui/react-ui/src/WalletModalButton.tsx
@@ -1,7 +1,7 @@
 import type { FC, MouseEvent } from 'react';
 import React, { useCallback } from 'react';
 import type { ButtonProps } from './Button.js';
-import { Button } from './Button.js';
+import { Button as BaseWalletConnectionButton } from './Button.js';
 import { useWalletModal } from './useWalletModal.js';
 
 export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet', onClick, ...props }) => {
@@ -16,8 +16,8 @@ export const WalletModalButton: FC<ButtonProps> = ({ children = 'Select Wallet',
     );
 
     return (
-        <Button className="wallet-adapter-button-trigger" onClick={handleClick} {...props}>
+        <BaseWalletConnectionButton {...props} className="wallet-adapter-button-trigger" onClick={handleClick}>
             {children}
-        </Button>
+        </BaseWalletConnectionButton>
     );
 };

--- a/packages/ui/react-ui/src/WalletMultiButton.tsx
+++ b/packages/ui/react-ui/src/WalletMultiButton.tsx
@@ -1,48 +1,19 @@
-import { useWallet } from '@solana/wallet-adapter-react';
-import type { FC } from 'react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useWalletMultiButton } from '@solana/wallet-adapter-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 import type { ButtonProps } from './Button.js';
-import { Button } from './Button.js';
 import { useWalletModal } from './useWalletModal.js';
-import { WalletConnectButton } from './WalletConnectButton.js';
-import { WalletIcon } from './WalletIcon.js';
-import { WalletModalButton } from './WalletModalButton.js';
 
-export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
-    const { publicKey, wallet, disconnect } = useWallet();
-    const { setVisible } = useWalletModal();
+export function WalletMultiButton({ children, ...props }: ButtonProps) {
+    const { setVisible: setModalVisible } = useWalletModal();
+    const { buttonState, onConnect, onDisconnect, publicKey, walletIcon, walletName } = useWalletMultiButton({
+        onSelectWallet() {
+            setModalVisible(true);
+        },
+    });
     const [copied, setCopied] = useState(false);
-    const [active, setActive] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
     const ref = useRef<HTMLUListElement>(null);
-
-    const base58 = useMemo(() => publicKey?.toBase58(), [publicKey]);
-    const content = useMemo(() => {
-        if (children) return children;
-        if (!wallet || !base58) return null;
-        return base58.slice(0, 4) + '..' + base58.slice(-4);
-    }, [children, wallet, base58]);
-
-    const copyAddress = useCallback(async () => {
-        if (base58) {
-            await navigator.clipboard.writeText(base58);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 400);
-        }
-    }, [base58]);
-
-    const openDropdown = useCallback(() => {
-        setActive(true);
-    }, []);
-
-    const closeDropdown = useCallback(() => {
-        setActive(false);
-    }, []);
-
-    const openModal = useCallback(() => {
-        setVisible(true);
-        closeDropdown();
-    }, [setVisible, closeDropdown]);
-
     useEffect(() => {
         const listener = (event: MouseEvent | TouchEvent) => {
             const node = ref.current;
@@ -50,7 +21,7 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
             // Do nothing if clicking dropdown or its descendants
             if (!node || node.contains(event.target as Node)) return;
 
-            closeDropdown();
+            setMenuOpen(false);
         };
 
         document.addEventListener('mousedown', listener);
@@ -60,39 +31,89 @@ export const WalletMultiButton: FC<ButtonProps> = ({ children, ...props }) => {
             document.removeEventListener('mousedown', listener);
             document.removeEventListener('touchstart', listener);
         };
-    }, [ref, closeDropdown]);
-
-    if (!wallet) return <WalletModalButton {...props}>{children}</WalletModalButton>;
-    if (!base58) return <WalletConnectButton {...props}>{children}</WalletConnectButton>;
-
+    }, []);
+    const content = useMemo(() => {
+        if (children) {
+            return children;
+        } else if (buttonState === 'connecting') {
+            return 'Connecting ...';
+        } else if (publicKey) {
+            const base58 = publicKey.toBase58();
+            return base58.slice(0, 4) + '..' + base58.slice(-4);
+        } else if (buttonState === 'has-wallet') {
+            return 'Connect';
+        } else {
+            return 'Select Wallet';
+        }
+    }, [buttonState, children, publicKey]);
     return (
         <div className="wallet-adapter-dropdown">
-            <Button
-                aria-expanded={active}
-                className="wallet-adapter-button-trigger"
-                style={{ pointerEvents: active ? 'none' : 'auto', ...props.style }}
-                onClick={openDropdown}
-                startIcon={<WalletIcon wallet={wallet} />}
+            <BaseWalletConnectionButton
                 {...props}
+                aria-expanded={menuOpen}
+                style={{ pointerEvents: menuOpen ? 'none' : 'auto', ...props.style }}
+                onClick={() => {
+                    switch (buttonState) {
+                        case 'no-wallet':
+                            setModalVisible(true);
+                            break;
+                        case 'has-wallet':
+                            if (onConnect) {
+                                onConnect();
+                            }
+                            break;
+                        case 'connected':
+                            setMenuOpen(true);
+                            break;
+                    }
+                }}
+                walletIcon={walletIcon}
+                walletName={walletName}
             >
                 {content}
-            </Button>
+            </BaseWalletConnectionButton>
             <ul
                 aria-label="dropdown-list"
-                className={`wallet-adapter-dropdown-list ${active && 'wallet-adapter-dropdown-list-active'}`}
+                className={`wallet-adapter-dropdown-list ${menuOpen && 'wallet-adapter-dropdown-list-active'}`}
                 ref={ref}
                 role="menu"
             >
-                <li onClick={copyAddress} className="wallet-adapter-dropdown-list-item" role="menuitem">
-                    {copied ? 'Copied' : 'Copy address'}
-                </li>
-                <li onClick={openModal} className="wallet-adapter-dropdown-list-item" role="menuitem">
+                {publicKey ? (
+                    <li
+                        className="wallet-adapter-dropdown-list-item"
+                        onClick={async () => {
+                            await navigator.clipboard.writeText(publicKey.toBase58());
+                            setCopied(true);
+                            setTimeout(() => setCopied(false), 400);
+                        }}
+                        role="menuitem"
+                    >
+                        {copied ? 'Copied' : 'Copy address'}
+                    </li>
+                ) : null}
+                <li
+                    className="wallet-adapter-dropdown-list-item"
+                    onClick={() => {
+                        setModalVisible(true);
+                        setMenuOpen(false);
+                    }}
+                    role="menuitem"
+                >
                     Change wallet
                 </li>
-                <li onClick={disconnect} className="wallet-adapter-dropdown-list-item" role="menuitem">
-                    Disconnect
-                </li>
+                {onDisconnect ? (
+                    <li
+                        className="wallet-adapter-dropdown-list-item"
+                        onClick={() => {
+                            onDisconnect();
+                            setMenuOpen(false);
+                        }}
+                        role="menuitem"
+                    >
+                        Disconnect
+                    </li>
+                ) : null}
             </ul>
         </div>
     );
-};
+}


### PR DESCRIPTION
feat: implement the React UI starter UI atop the new wallet UI hooks
## Summary

This PR proves out the `useWalletConnectButton`, `useWalletDisconnectButton` and `useWalletMultiButton` hooks by re-implementing the React UI UI package atop it. The package no longer uses `useWallet`, and has less connection-wrangling logic. This establishes a pattern that other developers can use to ship their own custom wallet connection UI.

## Test Plan

Loaded the example app and all three starter apps. Buttons work as they did before.

Finishes #658.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/wallet-adapter/pull/792).
* #793
* __->__ #792
* #791
* #790
* #789