### PR TITLE
Add onConnect and onDisconnect methods

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -13,12 +13,15 @@ import getInferredClusterFromEndpoint from './getInferredClusterFromEndpoint.js'
 import { useConnection } from './useConnection.js';
 import { useLocalStorage } from './useLocalStorage.js';
 import { WalletProviderBase } from './WalletProviderBase.js';
+import type { PublicKey } from '@solana/web3.js';
 
 export interface WalletProviderProps {
     children: ReactNode;
     wallets: Adapter[];
     autoConnect?: boolean | ((adapter: Adapter) => Promise<boolean>);
     localStorageKey?: string;
+    onConnect?: (publicKey?: PublicKey | null) => void;
+    onDisconnect?: () => void;
     onError?: (error: WalletError, adapter?: Adapter) => void;
 }
 
@@ -46,6 +49,8 @@ export function WalletProvider({
     wallets: adapters,
     autoConnect,
     localStorageKey = 'walletName',
+    onDisconnect,
+    onConnect,
     onError,
 }: WalletProviderProps) {
     const { connection } = useConnection();
@@ -171,6 +176,8 @@ export function WalletProvider({
             onConnectError={handleConnectError}
             onError={onError}
             onSelectWallet={selectWallet}
+            onConnect={onConnect}
+            onDisconnect={onDisconnect}
         >
             {children}
         </WalletProviderBase>

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -275,10 +275,6 @@ export function WalletProviderBase({
         } finally {
             setConnecting(false);
             isConnectingRef.current = false;
-
-            if (onConnect) {
-                onConnect(adapter.publicKey);
-            }
         }
     }, [onConnectError, wallet]);
 

--- a/packages/core/react/src/WalletProviderBase.tsx
+++ b/packages/core/react/src/WalletProviderBase.tsx
@@ -25,6 +25,8 @@ export interface WalletProviderBaseProps {
     onConnectError: () => void;
     onError?: (error: WalletError, adapter?: Adapter) => void;
     onSelectWallet: (walletName: WalletName | null) => void;
+    onConnect?: (publicKey?: PublicKey | null) => void;
+    onDisconnect?: () => void;
 }
 
 export function WalletProviderBase({
@@ -35,6 +37,8 @@ export function WalletProviderBase({
     onAutoConnectRequest,
     onConnectError,
     onError,
+    onConnect,
+    onDisconnect,
     onSelectWallet,
 }: WalletProviderBaseProps) {
     const isConnectingRef = useRef(false);
@@ -129,6 +133,10 @@ export function WalletProviderBase({
             setConnected(true);
             isDisconnectingRef.current = false;
             setDisconnecting(false);
+
+            if (onConnect) {
+                onConnect(publicKey);
+            }
         };
 
         const handleDisconnect = () => {
@@ -267,6 +275,10 @@ export function WalletProviderBase({
         } finally {
             setConnecting(false);
             isConnectingRef.current = false;
+
+            if (onConnect) {
+                onConnect(adapter.publicKey);
+            }
         }
     }, [onConnectError, wallet]);
 
@@ -280,6 +292,10 @@ export function WalletProviderBase({
         } finally {
             setDisconnecting(false);
             isDisconnectingRef.current = false;
+
+            if (onDisconnect) {
+                onDisconnect();
+            }
         }
     }, [adapter]);
 

--- a/packages/starter/react-ui-starter/src/App.tsx
+++ b/packages/starter/react-ui-starter/src/App.tsx
@@ -2,6 +2,7 @@ import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider, WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 import { UnsafeBurnerWalletAdapter } from '@solana/wallet-adapter-wallets';
+import type { PublicKey } from '@solana/web3.js';
 import { clusterApiUrl } from '@solana/web3.js';
 import type { FC, ReactNode } from 'react';
 import React, { useMemo } from 'react';
@@ -41,9 +42,12 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
         [network]
     );
 
+    const onConnectWallet = (publicKey?: PublicKey | null) => console.log(`connected to`, publicKey);
+    const onDisconnectWallet = () => console.log(`disconnected from wallet`);
+
     return (
         <ConnectionProvider endpoint={endpoint}>
-            <WalletProvider wallets={wallets} autoConnect>
+            <WalletProvider wallets={wallets} autoConnect onConnect={onConnectWallet} onDisconnect={onDisconnectWallet}>
                 <WalletModalProvider>{children}</WalletModalProvider>
             </WalletProvider>
         </ConnectionProvider>


### PR DESCRIPTION
### Description

This PR aims to add methods to be called when a wallet is connected and disconnected, this allow users to use adapter to:

- When disconnect redirect to login
- When connect redirect to home page
- Also we can validate when a wallet is changed using onConnect method by checking the publicKey without need to use any additional method call.


### Screenshot
<img width="960" alt="Captura de Tela 2023-08-14 às 00 25 09" src="https://github.com/solana-labs/wallet-adapter/assets/3375276/a5545582-b8cb-4df9-9bc6-866261ef7fda">
