### PR TITLE
Run build-and-test workflow on all PRs to master

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    branches: [master]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Some PRs have run the build-and-test job (eg https://github.com/solana-labs/wallet-adapter/pull/849 + https://github.com/solana-labs/wallet-adapter/pull/841), but some haven't (eg https://github.com/solana-labs/wallet-adapter/pull/840 + https://github.com/solana-labs/wallet-adapter/pull/838)

I'm unsure why this happens, but one guess is the missing `branches: [master]` on the `pull_request` trigger. 

This matches the trigger in eg web3js: https://github.com/solana-labs/solana-web3.js/blob/fdc85b98edc4bd7a74c5bd10128d5397bce368a7/.github/workflows/pull-requests.yml#L3-L5

The github docs also only seem to give examples that include a filter, eg https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore 

I'm hoping this will make all PRs run the build-and-test workflow! 