### PR TITLE
feat: revamp `particleAdapter`

### DIFF
--- a/packages/wallets/particle/package.json
+++ b/packages/wallets/particle/package.json
@@ -35,7 +35,6 @@
         "@solana/web3.js": "^1.77.3"
     },
     "dependencies": {
-        "@metamask/eth-sig-util": "^7.0.1",
         "@particle-network/solana-wallet": "1.2.1",
         "@solana/wallet-adapter-base": "workspace:^"
     },

--- a/packages/wallets/particle/package.json
+++ b/packages/wallets/particle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-particle",
-    "version": "0.1.11",
+    "version": "0.1.10",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",

--- a/packages/wallets/particle/package.json
+++ b/packages/wallets/particle/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/wallet-adapter-particle",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-adapter",
     "license": "Apache-2.0",
@@ -35,7 +35,8 @@
         "@solana/web3.js": "^1.77.3"
     },
     "dependencies": {
-        "@particle-network/solana-wallet": "^0.5.6",
+        "@metamask/eth-sig-util": "^7.0.1",
+        "@particle-network/solana-wallet": "1.2.1",
         "@solana/wallet-adapter-base": "workspace:^"
     },
     "devDependencies": {

--- a/packages/wallets/particle/src/adapter.ts
+++ b/packages/wallets/particle/src/adapter.ts
@@ -80,11 +80,11 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
         };
     }
 
-    public get auth(): ParticleNetwork['auth'] {
+    public get particle(): ParticleNetwork {
         if (!this._particleNetwork) {
             throw new Error('ParticleNetwork is not initialized.');
         }
-        return this._particleNetwork.auth;
+        return this._particleNetwork;
     }
 
     get publicKey() {

--- a/packages/wallets/particle/src/adapter.ts
+++ b/packages/wallets/particle/src/adapter.ts
@@ -4,7 +4,6 @@ import {
     BaseMessageSignerWalletAdapter,
     WalletAccountError,
     WalletConfigError,
-    WalletConnectionError,
     WalletDisconnectionError,
     WalletLoadError,
     WalletNotConnectedError,
@@ -17,8 +16,17 @@ import {
 import type { Transaction } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
+interface NestedConfig {
+    chainId?: number;
+    chainName?: string;
+    projectId: string;
+    clientKey: string;
+    appId: string;
+}
+
 export interface ParticleAdapterConfig {
-    config?: Config;
+    config: NestedConfig;
+    preferredAuthType?: string;
 }
 
 export const ParticleName = 'Particle' as WalletName<'Particle'>;
@@ -37,12 +45,37 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
     private _readyState: WalletReadyState =
         typeof window === 'undefined' ? WalletReadyState.Unsupported : WalletReadyState.Loadable;
 
-    constructor(config: ParticleAdapterConfig = {}) {
+    private _particleNetwork: ParticleNetwork | null = null;
+
+    constructor(config: ParticleAdapterConfig) {
         super();
         this._connecting = false;
         this._publicKey = null;
         this._wallet = null;
-        this._config = config;
+
+        const nestedConfig: NestedConfig = config.config || {};
+
+        const chainId = nestedConfig.chainId !== undefined ? nestedConfig.chainId : 101;
+        const chainName = nestedConfig.chainName !== undefined ? nestedConfig.chainName : 'solana';
+
+        this._config = {
+            ...config,
+            config: {
+                ...nestedConfig,
+                chainId,
+                chainName,
+                projectId: nestedConfig.projectId,
+                clientKey: nestedConfig.clientKey,
+                appId: nestedConfig.appId,
+            },
+        };
+    }
+
+    public get auth(): ParticleNetwork['auth'] {
+        if (!this._particleNetwork) {
+            throw new Error('ParticleNetwork is not initialized.');
+        }
+        return this._particleNetwork.auth;
     }
 
     get publicKey() {
@@ -66,6 +99,7 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
 
             let ParticleClass: typeof ParticleNetwork;
             let WalletClass: typeof SolanaWallet;
+
             try {
                 ({ ParticleNetwork: ParticleClass, SolanaWallet: WalletClass } = await import(
                     '@particle-network/solana-wallet'
@@ -74,17 +108,29 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletLoadError(error?.message, error);
             }
 
-            let wallet: SolanaWallet;
+            let particleNetwork: ParticleNetwork;
+
+            const authOptions: any = {};
+            if (this._config.preferredAuthType) {
+                authOptions.preferredAuthType = this._config.preferredAuthType;
+            }
+
             try {
-                wallet = new WalletClass(new ParticleClass(this._config?.config).auth);
+                particleNetwork = new ParticleClass(this._config?.config as Config);
+                if (!particleNetwork.auth.isLogin()) {
+                    await particleNetwork.auth.login(authOptions);
+                }
             } catch (error: any) {
                 throw new WalletConfigError(error?.message, error);
             }
 
+            this._particleNetwork = particleNetwork;
+
+            let wallet: SolanaWallet;
             try {
-                await wallet.connect();
+                wallet = new WalletClass(particleNetwork.auth);
             } catch (error: any) {
-                throw new WalletConnectionError(error?.message, error);
+                throw new WalletConfigError(error?.message, error);
             }
 
             const account = wallet.publicKey;

--- a/packages/wallets/particle/src/adapter.ts
+++ b/packages/wallets/particle/src/adapter.ts
@@ -15,6 +15,7 @@ import {
 } from '@solana/wallet-adapter-base';
 import type { Transaction } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
+import { LoginOptions } from '@particle-network/auth';
 
 interface NestedConfig {
     chainId?: number;
@@ -80,10 +81,7 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
         };
     }
 
-    public get particle(): ParticleNetwork {
-        if (!this._particleNetwork) {
-            throw new Error('ParticleNetwork is not initialized.');
-        }
+    public get particle(): ParticleNetwork | null {
         return this._particleNetwork;
     }
 
@@ -119,9 +117,9 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
 
             let particleNetwork: ParticleNetwork;
 
-            const authOptions: any = {};
+            const authOptions: LoginOptions = {};
             if (this._config.preferredAuthType) {
-                authOptions.preferredAuthType = this._config.preferredAuthType;
+                authOptions.preferredAuthType = this._config.preferredAuthType as LoginOptions['preferredAuthType'];
             }
 
             try {
@@ -132,8 +130,6 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
             } catch (error: any) {
                 throw new WalletConfigError(error?.message, error);
             }
-
-            this._particleNetwork = particleNetwork;
 
             let wallet: SolanaWallet;
             try {
@@ -153,6 +149,7 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
             }
 
             this._wallet = wallet;
+            this._particleNetwork = particleNetwork;
             this._publicKey = publicKey;
 
             this.emit('connect', publicKey);

--- a/packages/wallets/particle/src/adapter.ts
+++ b/packages/wallets/particle/src/adapter.ts
@@ -53,16 +53,16 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
         this._publicKey = null;
         this._wallet = null;
 
-      const defaultNestedConfig: NestedConfig = {
-          projectId: '',
-          clientKey: '',
-          appId: '',
-      };
-      
-      const nestedConfig: NestedConfig = {
-          ...defaultNestedConfig,
-          ...config.config,
-      };
+        const defaultNestedConfig: NestedConfig = {
+            projectId: '',
+            clientKey: '',
+            appId: '',
+        };
+
+        const nestedConfig: NestedConfig = {
+            ...defaultNestedConfig,
+            ...config.config,
+        };
 
         const chainId = nestedConfig.chainId !== undefined ? nestedConfig.chainId : 101;
         const chainName = nestedConfig.chainName !== undefined ? nestedConfig.chainName : 'solana';

--- a/packages/wallets/particle/src/adapter.ts
+++ b/packages/wallets/particle/src/adapter.ts
@@ -25,7 +25,7 @@ interface NestedConfig {
 }
 
 export interface ParticleAdapterConfig {
-    config: NestedConfig;
+    config?: NestedConfig;
     preferredAuthType?: string;
 }
 
@@ -47,13 +47,22 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
 
     private _particleNetwork: ParticleNetwork | null = null;
 
-    constructor(config: ParticleAdapterConfig) {
+    constructor(config: ParticleAdapterConfig = {}) {
         super();
         this._connecting = false;
         this._publicKey = null;
         this._wallet = null;
 
-        const nestedConfig: NestedConfig = config.config || {};
+      const defaultNestedConfig: NestedConfig = {
+          projectId: '',
+          clientKey: '',
+          appId: '',
+      };
+      
+      const nestedConfig: NestedConfig = {
+          ...defaultNestedConfig,
+          ...(config.config as NestedConfig || {}),
+      };
 
         const chainId = nestedConfig.chainId !== undefined ? nestedConfig.chainId : 101;
         const chainName = nestedConfig.chainName !== undefined ? nestedConfig.chainName : 'solana';

--- a/packages/wallets/particle/src/adapter.ts
+++ b/packages/wallets/particle/src/adapter.ts
@@ -61,7 +61,7 @@ export class ParticleAdapter extends BaseMessageSignerWalletAdapter {
       
       const nestedConfig: NestedConfig = {
           ...defaultNestedConfig,
-          ...(config.config as NestedConfig || {}),
+          ...config.config,
       };
 
         const chainId = nestedConfig.chainId !== undefined ? nestedConfig.chainId : 101;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 8.8.0(eslint@8.22.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.22.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.22.0)(prettier@3.1.1)
       eslint-plugin-react:
         specifier: ^7.32.2
         version: 7.33.0(eslint@8.22.0)
@@ -52,8 +52,8 @@ importers:
         specifier: ^8.6.3
         version: 8.6.9
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.1.1
+        version: 3.1.1
       shx:
         specifier: ^0.3.4
         version: 0.3.4
@@ -904,13 +904,19 @@ importers:
 
   packages/wallets/particle:
     dependencies:
+      '@particle-network/auth':
+        specifier: ^1.2.1
+        version: 1.2.2
       '@particle-network/solana-wallet':
-        specifier: ^0.5.6
-        version: 0.5.6(@solana/web3.js@1.78.0)(bs58@4.0.1)
+        specifier: 1.2.1
+        version: 1.2.1(@particle-network/auth@1.2.2)(@solana/web3.js@1.78.0)(bs58@4.0.1)
       '@solana/wallet-adapter-base':
         specifier: workspace:^
         version: link:../../core/base
     devDependencies:
+      '@metamask/eth-sig-util':
+        specifier: ^7.0.1
+        version: 7.0.1
       '@solana/web3.js':
         specifier: ^1.77.3
         version: 1.78.0
@@ -1398,7 +1404,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': '>=7.11.0'
-      eslint: ^7.5.0 || ^8.0.0
+      eslint: 8.22.0
     dependencies:
       '@babel/core': 7.22.9
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
@@ -3342,7 +3348,7 @@ packages:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+      eslint: 8.22.0
     dependencies:
       eslint: 8.22.0
       eslint-visitor-keys: 3.4.1
@@ -3372,13 +3378,11 @@ packages:
     dependencies:
       '@ethereumjs/util': 8.1.0
       crc-32: 1.2.2
-    dev: false
 
   /@ethereumjs/rlp@4.0.1:
     resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: false
 
   /@ethereumjs/tx@4.2.0:
     resolution: {integrity: sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==}
@@ -3388,7 +3392,6 @@ packages:
       '@ethereumjs/rlp': 4.0.1
       '@ethereumjs/util': 8.1.0
       ethereum-cryptography: 2.1.2
-    dev: false
 
   /@ethereumjs/util@8.1.0:
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
@@ -3397,7 +3400,6 @@ packages:
       '@ethereumjs/rlp': 4.0.1
       ethereum-cryptography: 2.1.2
       micro-ftch: 0.3.1
-    dev: false
 
   /@fractalwagmi/popup-connection@1.1.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-hYL+45iYwNbwjvP2DxP3YzVsrAGtj/RV9LOgMpJyCxsfNoyyOoi2+YrnywKkiANingiG2kJ1nKsizbu1Bd4zZw==}
@@ -4132,6 +4134,30 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
+  /@metamask/abi-utils@2.0.2:
+    resolution: {integrity: sha512-B/A1dY/w4F/t6cDHUscklO6ovb/ztFsrsTXFd8QlqSByk/vyy+QbPE3VVpmmyI/7RX+PA1AJcvBdzCIz+r9dVQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@metamask/utils': 8.2.1
+      superstruct: 1.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@metamask/eth-sig-util@7.0.1:
+    resolution: {integrity: sha512-59GSrMyFH2fPfu7nKeIQdZ150zxXNNhAQIUaFRUW+MGtVA4w/ONbiQobcRBLi+jQProfIyss51G8pfLPcQ0ylg==}
+    engines: {node: ^16.20 || ^18.16 || >=20}
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      '@metamask/abi-utils': 2.0.2
+      '@metamask/utils': 8.2.1
+      ethereum-cryptography: 2.1.2
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@metamask/rpc-errors@5.1.1:
     resolution: {integrity: sha512-JjZnDi2y2CfvbohhBl+FOQRzmFlJpybcQlIk37zEX8B96eVSPbH/T8S0p7cSF8IE33IWx6JkD8Ycsd+2TXFxCw==}
     engines: {node: '>=16.0.0'}
@@ -4154,6 +4180,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /@metamask/utils@8.2.1:
+    resolution: {integrity: sha512-dlnpow8r0YHDDL1xKCEwUoTGOAo9icdv+gaJG0EbgDnkD/BDqW2eH1XMtm9i7rPaiHWo/aLtcrh9WBhkCq/viw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@ethereumjs/tx': 4.2.0
+      '@noble/hashes': 1.3.1
+      '@scure/base': 1.1.5
+      '@types/debug': 4.1.8
+      debug: 4.3.4
+      pony-cause: 2.1.10
+      semver: 7.5.4
+      superstruct: 1.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@mischnic/json-sourcemap@0.1.0:
     resolution: {integrity: sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==}
@@ -5342,20 +5384,42 @@ packages:
       nullthrows: 1.1.1
     dev: true
 
-  /@particle-network/auth@0.5.6:
-    resolution: {integrity: sha512-QhRr76BamasIatyWc68Whk/JpjomKUFbxT4KoHxrSWD8lmyWTOP5T8Jo8hQliyjtO2Iuzv9KLpuJ55w7mgaC/A==}
+  /@particle-network/analytics@1.0.1:
+    resolution: {integrity: sha512-ApcSMo1BXQlywO+lvOpG3Y2/SVGNCpJzXO/4e3zHzE/9j+uMehsilDzPwWQwLhrCXZYwVm7mmE71Gs36yobiNw==}
     dependencies:
-      crypto-js: 4.1.1
-      uuid: 8.3.2
+      hash.js: 1.1.7
+      uuidv4: 6.2.13
     dev: false
 
-  /@particle-network/solana-wallet@0.5.6(@solana/web3.js@1.78.0)(bs58@4.0.1):
-    resolution: {integrity: sha512-Ad0hwJsWRCbptp+mmLFsbrERDQbW+QhFQOmWRT8+6gGrY6qNTApwI9+jlpkxOzEI9rvSqFD1qKKMlqy1n+fJNA==}
+  /@particle-network/auth@1.2.2:
+    resolution: {integrity: sha512-xm5j+qex8z0cYxNy9XuxVaIBdb1x7edl4W5XDWx1Px/TdtuqbhGwMsCGbzkTc++yB/LTSIXzzdbDW8a4gRU/gQ==}
+    dependencies:
+      '@particle-network/analytics': 1.0.1
+      '@particle-network/chains': 1.3.3
+      '@particle-network/crypto': 1.0.1
+      buffer: 6.0.3
+      draggabilly: 3.0.0
+    dev: false
+
+  /@particle-network/chains@1.3.3:
+    resolution: {integrity: sha512-M/h5YwvtEJ4zk3ssF6fAUl0jRGFNhdN+K6YgxVbswJgFVD1pKNYMQgN+5hkV6YNUzuhqgTb0y9a4ol+tVZeVIQ==}
+    dev: false
+
+  /@particle-network/crypto@1.0.1:
+    resolution: {integrity: sha512-GgvHmHcFiNkCLZdcJOgctSbgvs251yp+EAdUydOE3gSoIxN6KEr/Snu9DebENhd/nFb7FDk5ap0Hg49P7pj1fg==}
+    dependencies:
+      crypto-js: 4.1.1
+      uuidv4: 6.2.13
+    dev: false
+
+  /@particle-network/solana-wallet@1.2.1(@particle-network/auth@1.2.2)(@solana/web3.js@1.78.0)(bs58@4.0.1):
+    resolution: {integrity: sha512-s7kG1NdC+aB4+pp4KGr+N9DwPUEG6V1rYVh3n3xRDjXBd7QoycY8UZIyKthELeSrBrTQdr2rSq3Dhmh4LAtOCg==}
     peerDependencies:
+      '@particle-network/auth': '*'
       '@solana/web3.js': ^1.50.1
       bs58: ^4.0.1
     dependencies:
-      '@particle-network/auth': 0.5.6
+      '@particle-network/auth': 1.2.2
       '@solana/web3.js': 1.78.0
       bs58: 4.0.1
     dev: false
@@ -5722,7 +5786,10 @@ packages:
 
   /@scure/base@1.1.1:
     resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
-    dev: false
+
+  /@scure/base@1.1.5:
+    resolution: {integrity: sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==}
+    dev: true
 
   /@scure/bip32@1.3.1:
     resolution: {integrity: sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==}
@@ -5730,14 +5797,12 @@ packages:
       '@noble/curves': 1.1.0
       '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
-    dev: false
 
   /@scure/bip39@1.2.1:
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
     dependencies:
       '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
-    dev: false
 
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -5881,7 +5946,7 @@ packages:
     resolution: {integrity: sha512-bkCPtOHWMXsCpqudoOQ2BSMAJQAcPrgAApDROGI4zpPIM1GI8WA7QslS9MJgSvkWKIRIUdf1r6YnpVSwT6c8sw==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/wallet-adapter-base': '*'
+      '@solana/wallet-adapter-base': workspace:^
       react: '*'
     dependencies:
       '@solana/wallet-adapter-base': link:packages/core/base
@@ -6604,7 +6669,6 @@ packages:
     resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
     dependencies:
       '@types/ms': 0.7.31
-    dev: false
 
   /@types/eslint-scope@3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
@@ -6722,7 +6786,6 @@ packages:
 
   /@types/ms@0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
-    dev: false
 
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
@@ -6879,6 +6942,10 @@ packages:
     resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
     dev: false
 
+  /@types/uuid@8.3.4:
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+    dev: false
+
   /@types/w3c-web-hid@1.0.3:
     resolution: {integrity: sha512-eTQRkPd2JukZfS9+kRtrBAaTCCb6waGh5X8BJHmH1MiVQPLMYwm4+EvhwFfOo9SDna15o9dFAwmWwN6r/YM53A==}
     dev: true
@@ -6919,7 +6986,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: 8.22.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -6945,7 +7012,7 @@ packages:
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: 8.22.0
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.22.0)(typescript@4.7.4)
       eslint: 8.22.0
@@ -6958,7 +7025,7 @@ packages:
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: 8.22.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -6984,7 +7051,7 @@ packages:
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: 8.22.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -7027,7 +7094,7 @@ packages:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: 8.22.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.22.0)
       '@types/json-schema': 7.0.12
@@ -8938,7 +9005,6 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
-    dev: false
 
   /crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
@@ -9641,6 +9707,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /draggabilly@3.0.0:
+    resolution: {integrity: sha512-aEs+B6prbMZQMxc9lgTpCBfyCUhRur/VFucHhIOvlvvdARTj7TcDmX/cdOUtqbjJJUh7+agyJXR5Z6IFe1MxwQ==}
+    dependencies:
+      get-size: 3.0.0
+      unidragger: 3.0.1
+    dev: false
+
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: false
@@ -9923,7 +9996,7 @@ packages:
   /eslint-config-next@12.3.4(eslint@8.22.0)(typescript@4.7.4):
     resolution: {integrity: sha512-WuT3gvgi7Bwz00AOmKGhOeqnyA5P29Cdyr0iVjLyfDbk+FANQKcOjFUTZIdyYfe5Tq1x4TGcmoe4CwctGvFjHQ==}
     peerDependencies:
-      eslint: ^7.23.0 || ^8.0.0
+      eslint: 8.22.0
       typescript: '>=3.3.1'
     peerDependenciesMeta:
       typescript:
@@ -9949,7 +10022,7 @@ packages:
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
-      eslint: '>=7.0.0'
+      eslint: 8.22.0
     dependencies:
       eslint: 8.22.0
     dev: true
@@ -9958,7 +10031,7 @@ packages:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      eslint: ^8.0.0
+      eslint: 8.22.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -10002,7 +10075,7 @@ packages:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: '*'
+      eslint: 8.22.0
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4
@@ -10050,7 +10123,7 @@ packages:
     peerDependencies:
       '@babel/plugin-syntax-flow': ^7.14.5
       '@babel/plugin-transform-react-jsx': ^7.14.9
-      eslint: ^8.1.0
+      eslint: 8.22.0
     dependencies:
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.22.9)
@@ -10064,7 +10137,7 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: 8.22.0
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
@@ -10096,7 +10169,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: 8.22.0
       jest: '*'
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
@@ -10117,7 +10190,7 @@ packages:
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: 8.22.0
     dependencies:
       '@babel/runtime': 7.22.6
       aria-query: 5.3.0
@@ -10137,11 +10210,11 @@ packages:
       object.fromentries: 2.0.6
       semver: 6.3.1
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.22.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.22.0)(prettier@3.1.1):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      eslint: '>=7.28.0'
+      eslint: 8.22.0
       eslint-config-prettier: '*'
       prettier: '>=2.0.0'
     peerDependenciesMeta:
@@ -10150,7 +10223,7 @@ packages:
     dependencies:
       eslint: 8.22.0
       eslint-config-prettier: 8.8.0(eslint@8.22.0)
-      prettier: 2.8.8
+      prettier: 3.1.1
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -10158,7 +10231,7 @@ packages:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: 8.22.0
     dependencies:
       eslint: 8.22.0
 
@@ -10166,7 +10239,7 @@ packages:
     resolution: {integrity: sha512-qewL/8P34WkY8jAqdQxsiL82pDUeT7nhs8IsuXgfgnsEloKCT4miAV9N9kGtx7/KM9NH/NCGUE7Edt9iGxLXFw==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: 8.22.0
     dependencies:
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
@@ -10189,7 +10262,7 @@ packages:
     resolution: {integrity: sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==}
     engines: {node: '>=16'}
     peerDependencies:
-      eslint: '*'
+      eslint: 8.22.0
     dependencies:
       eslint: 8.22.0
     dev: true
@@ -10198,7 +10271,7 @@ packages:
     resolution: {integrity: sha512-ELY7Gefo+61OfXKlQeXNIDVVLPcvKTeiQOoMZG9TeuWa7Ln4dUNRv8JdRWBQI9Mbb427XGlVB1aa1QPZxBJM8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
+      eslint: 8.22.0
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.22.0)(typescript@4.7.4)
       eslint: 8.22.0
@@ -10225,7 +10298,7 @@ packages:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
-      eslint: '>=5'
+      eslint: 8.22.0
     dependencies:
       eslint: 8.22.0
       eslint-visitor-keys: 2.1.0
@@ -10242,7 +10315,7 @@ packages:
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: 8.22.0
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.44.0
@@ -10360,6 +10433,9 @@ packages:
       '@noble/hashes': 1.3.1
       '@scure/bip32': 1.3.1
       '@scure/bip39': 1.2.1
+
+  /ev-emitter@2.1.2:
+    resolution: {integrity: sha512-jQ5Ql18hdCQ4qS+RCrbLfz1n+Pags27q5TwMKvZyhp5hh2UULUYZUy1keqj6k6SYsdqIYjnmz7xyyEY0V67B8Q==}
     dev: false
 
   /event-target-shim@5.0.1:
@@ -10715,7 +10791,7 @@ packages:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
-      eslint: '>= 6'
+      eslint: 8.22.0
       typescript: '>= 2.7'
       vue-template-compiler: '*'
       webpack: '>= 4'
@@ -10870,6 +10946,10 @@ packages:
     resolution: {integrity: sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==}
     engines: {node: '>=6'}
     dev: true
+
+  /get-size@3.0.0:
+    resolution: {integrity: sha512-Y8aiXLq4leR7807UY0yuKEwif5s3kbVp1nTv+i4jBeoUzByTLKkLWu/HorS6/pB+7gsB0o7OTogC8AoOOeT0Hw==}
+    dev: false
 
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -13894,7 +13974,6 @@ packages:
 
   /micro-ftch@0.3.1:
     resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
-    dev: false
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -14210,6 +14289,7 @@ packages:
   /node-gyp-build-optional-packages@5.0.7:
     resolution: {integrity: sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -14791,6 +14871,11 @@ packages:
     resolution: {integrity: sha512-LPEaCGvlV4dVGeJeHqi/pCR/SETooqmScv2wcr0gTqGUebpkt1w9TIEX0awLMhLO29p7pcXfz5ZO59B70Tnc0w==}
     engines: {node: '>=16.14'}
     hasBin: true
+    dev: true
+
+  /pony-cause@2.1.10:
+    resolution: {integrity: sha512-3IKLNXclQgkU++2fSi93sQ6BznFuxSLB11HdvZQ6JW/spahf/P1pAHBQEahr20rs0htZW0UDkM1HmA+nZkXKsw==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /postcss-attribute-case-insensitive@5.0.2(postcss@8.4.26):
@@ -15638,6 +15723,12 @@ packages:
     hasBin: true
     dev: true
 
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -15727,6 +15818,7 @@ packages:
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -16580,7 +16672,7 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:
-      eslint: '*'
+      eslint: 8.22.0
       react: '>= 16'
       typescript: ^3.2.1 || ^4
     peerDependenciesMeta:
@@ -17884,7 +17976,6 @@ packages:
   /superstruct@1.0.3:
     resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
     engines: {node: '>=14.0.0'}
-    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -18333,6 +18424,14 @@ packages:
       turbo-windows-arm64: 1.10.9
     dev: true
 
+  /tweetnacl-util@0.15.1:
+    resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
+    dev: true
+
+  /tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+    dev: true
+
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -18490,6 +18589,12 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /unidragger@3.0.1:
+    resolution: {integrity: sha512-RngbGSwBFmqGBWjkaH+yB677uzR95blSQyxq6hYbrQCejH3Mx1nm8DVOuh3M9k2fQyTstWUG5qlgCnNqV/9jVw==}
+    dependencies:
+      ev-emitter: 2.1.2
+    dev: false
+
   /unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -18614,6 +18719,13 @@ packages:
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
+    dev: false
+
+  /uuidv4@6.2.13:
+    resolution: {integrity: sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==}
+    dependencies:
+      '@types/uuid': 8.3.4
+      uuid: 8.3.2
     dev: false
 
   /v8-compile-cache@2.3.0:


### PR DESCRIPTION
As an alternative to the previous PR, this purely updates the adapter to function with the new version of Particle's `solana-wallet` SDK, restoring standard functionality to the adapter (which it currently lacks due to the outdated structure and `solana-wallet` version). 

This removes the previous social login display customization changes & abides by the 1 SDK rule.