### PR TITLE
Prevents multiple bindings of the disconnect event handler

### DIFF
--- a/packages/wallets/alpha/src/adapter.ts
+++ b/packages/wallets/alpha/src/adapter.ts
@@ -62,6 +62,7 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: AlphaWalletAdapterConfig = {}) {
         super();
@@ -106,6 +107,7 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.alpha!;
+            if (!wallet) throw new WalletNotReadyError();
 
             if (!wallet.isConnected) {
                 try {
@@ -124,7 +126,10 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -141,7 +146,10 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -235,10 +243,13 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -246,5 +257,5 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/coinbase/src/adapter.ts
+++ b/packages/wallets/coinbase/src/adapter.ts
@@ -59,6 +59,7 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: CoinbaseWalletAdapterConfig = {}) {
         super();
@@ -99,6 +100,7 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.coinbaseSolana!;
+            if (!wallet) throw new WalletNotReadyError();
 
             try {
                 await wallet.connect();
@@ -115,7 +117,10 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -132,7 +137,10 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -226,10 +234,13 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -237,5 +248,5 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/huobi/src/adapter.ts
+++ b/packages/wallets/huobi/src/adapter.ts
@@ -55,6 +55,7 @@ export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: HuobiWalletAdapterConfig = {}) {
         super();
@@ -99,6 +100,7 @@ export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.huobiWallet!;
+            if (!wallet) throw new WalletNotReadyError();
 
             try {
                 await wallet.connect();
@@ -115,7 +117,10 @@ export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -132,7 +137,10 @@ export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -190,10 +198,13 @@ export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -201,5 +212,5 @@ export class HuobiWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/saifu/src/adapter.ts
+++ b/packages/wallets/saifu/src/adapter.ts
@@ -62,6 +62,7 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: SaifuWalletAdapterConfig = {}) {
         super();
@@ -106,6 +107,7 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.saifu!;
+            if (!wallet) throw new WalletNotReadyError();
 
             if (!wallet.isConnected) {
                 try {
@@ -124,7 +126,10 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -141,7 +146,10 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -239,10 +247,13 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -250,5 +261,5 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/salmon/src/adapter.ts
+++ b/packages/wallets/salmon/src/adapter.ts
@@ -47,6 +47,7 @@ export class SalmonWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.Loadable;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor({ network = WalletAdapterNetwork.Mainnet }: SalmonWalletAdapterConfig = {}) {
         super();
@@ -105,6 +106,7 @@ export class SalmonWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletConfigError(error?.message, error);
             }
 
+            if (!wallet) throw new WalletNotReadyError();
             if (!wallet.connected) {
                 try {
                     await wallet.connect();
@@ -122,7 +124,10 @@ export class SalmonWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -139,7 +144,10 @@ export class SalmonWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -202,10 +210,13 @@ export class SalmonWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -213,5 +224,5 @@ export class SalmonWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/spot/src/adapter.ts
+++ b/packages/wallets/spot/src/adapter.ts
@@ -55,6 +55,7 @@ export class SpotWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: SpotWalletAdapterConfig = {}) {
         super();
@@ -99,6 +100,7 @@ export class SpotWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.spotSolWallet!;
+            if (!wallet) throw new WalletNotReadyError();
 
             try {
                 await wallet.connect();
@@ -115,7 +117,10 @@ export class SpotWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -132,7 +137,10 @@ export class SpotWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -196,10 +204,13 @@ export class SpotWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -207,5 +218,5 @@ export class SpotWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/trust/src/adapter.ts
+++ b/packages/wallets/trust/src/adapter.ts
@@ -64,6 +64,7 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: TrustWalletAdapterConfig = {}) {
         super();
@@ -108,6 +109,7 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.trustwallet!.solana!;
+            if (!wallet) throw new WalletNotReadyError();
 
             if (!wallet.isConnected) {
                 try {
@@ -126,7 +128,10 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -143,7 +148,10 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -237,10 +245,13 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -248,5 +259,5 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }

--- a/packages/wallets/xdefi/src/adapter.ts
+++ b/packages/wallets/xdefi/src/adapter.ts
@@ -62,6 +62,7 @@ export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
         typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.NotDetected;
+    private _onDisconnectBound: (() => void) | null = null;
 
     constructor(config: XDEFIWalletAdapterConfig = {}) {
         super();
@@ -106,6 +107,7 @@ export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const wallet = window.xfi!.solana!;
+            if (!wallet) throw new WalletNotReadyError();
 
             if (!wallet.isConnected) {
                 try {
@@ -124,7 +126,10 @@ export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
                 throw new WalletPublicKeyError(error?.message, error);
             }
 
-            wallet.on('disconnect', this._disconnected);
+            if (!this._onDisconnectBound) {
+                this._onDisconnectBound = this._disconnected.bind(this);
+                wallet.on('disconnect', this._onDisconnectBound);
+            }
 
             this._wallet = wallet;
             this._publicKey = publicKey;
@@ -141,7 +146,10 @@ export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
     async disconnect(): Promise<void> {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -205,10 +213,13 @@ export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    private _disconnected = () => {
+    private _disconnected() {
         const wallet = this._wallet;
         if (wallet) {
-            wallet.off('disconnect', this._disconnected);
+            if (this._onDisconnectBound) {
+                wallet.off('disconnect', this._onDisconnectBound);
+                this._onDisconnectBound = null;
+            }
 
             this._wallet = null;
             this._publicKey = null;
@@ -216,5 +227,5 @@ export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', new WalletDisconnectedError());
             this.emit('disconnect');
         }
-    };
+    }
 }


### PR DESCRIPTION
**Issue:**
 if the wallet emits the disconnect event more than once, the `_disconnected` method will be added multiple times as an event listener. This might lead to unexpected issues.


**Fix:**
Added  `_onDisconnectBound` to store the bound `_disconnected` method. In the connect method, the `_disconnected` method is bound and set to `_onDisconnectBound` only if it hasn't been set already. This prevents multiple bindings of the same event handler.