### PR TITLE
Add readme in starter/ pointing to create-solana-dapp

### DIFF
--- a/packages/starter/README.md
+++ b/packages/starter/README.md
@@ -1,0 +1,5 @@
+# Example projects
+
+Please note that the starter/example projects here are primarily for testing in-development versions of wallet-adapter. While some components/code may be useful, they cannot be copy-pasted and used to start building a new dapp as-is.
+
+The recommended way to create a new Solana dapp is using [create-solana-dapp](https://github.com/solana-developers/create-solana-dapp). All frontend templates include wallet-adapter support. 


### PR DESCRIPTION
There's been confusion around the starter/ projects in this directory. These can't be used as-is because they use `workspace:` dependencies from elsewhere in this repo. [create-solana-dapp](https://github.com/solana-developers/create-solana-dapp) is a much better place for someone to start when creating a new dapp. This PR adds a readme to the `starter/` directory which contains all the starter/example projects that will hopefully point people in the right direction. 